### PR TITLE
fix: add missing documentation pipeline files and scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,12 @@
     "db:generate": "prisma generate",
     "db:push": "prisma db push",
     "db:studio": "prisma studio",
+    "docs:dev": "vitepress dev docs",
+    "docs:build": "vitepress build docs",
+    "docs:preview": "vitepress preview docs",
+    "docs:typedoc": "typedoc",
+    "docs:openapi": "npx tsx scripts/generate-openapi.ts",
+    "docs:all": "npm run docs:typedoc && npm run docs:openapi && npm run docs:build",
     "test": "playwright test",
     "test:headed": "playwright test --headed",
     "test:ui": "playwright test --ui",
@@ -37,12 +43,14 @@
     "zod": "^4.1.8"
   },
   "devDependencies": {
+    "@asteasolutions/zod-to-openapi": "^8.2.0",
     "@commitlint/cli": "^20.3.0",
     "@commitlint/config-conventional": "^20.3.0",
     "@eslint/eslintrc": "^3",
     "@playwright/test": "^1.57.0",
     "@tailwindcss/postcss": "^4",
     "@types/bcryptjs": "^3.0.0",
+    "@types/js-yaml": "^4.0.9",
     "@types/jsonwebtoken": "^9.0.10",
     "@types/node": "^20",
     "@types/qrcode": "^1.5.6",
@@ -51,9 +59,15 @@
     "eslint": "^9",
     "eslint-config-next": "15.5.3",
     "husky": "^9.1.7",
+    "js-yaml": "^4.1.1",
+    "mermaid": "^11.12.2",
     "prettier": "^3.7.4",
     "prettier-plugin-tailwindcss": "^0.7.2",
     "tailwindcss": "^4",
-    "typescript": "^5"
+    "typedoc": "^0.28.15",
+    "typedoc-plugin-markdown": "^4.9.0",
+    "typescript": "^5",
+    "vitepress": "^1.6.4",
+    "vitepress-plugin-mermaid": "^2.0.17"
   }
 }

--- a/scripts/generate-openapi.ts
+++ b/scripts/generate-openapi.ts
@@ -1,0 +1,139 @@
+import {
+  OpenApiGeneratorV3,
+  OpenAPIRegistry,
+  extendZodWithOpenApi,
+} from '@asteasolutions/zod-to-openapi';
+import { z } from 'zod';
+import * as fs from 'fs';
+import * as yaml from 'js-yaml';
+
+// Extend Zod
+extendZodWithOpenApi(z);
+
+const registry = new OpenAPIRegistry();
+
+// 1. Define Common Schemas
+const ErrorSchema = registry.register(
+  'Error',
+  z.object({
+    error: z.object({
+      type: z.string(),
+      message: z.string(),
+      details: z.any().optional(),
+    }),
+  })
+);
+
+const UserSchema = registry.register(
+  'User',
+  z.object({
+    id: z.string().cuid(),
+    email: z.string().email(),
+    username: z.string().optional(),
+    firstName: z.string().optional(),
+    lastName: z.string().optional(),
+    role: z.enum(['USER', 'ADMIN', 'MODERATOR']),
+    isActive: z.boolean(),
+    emailVerified: z.boolean(),
+    lastLoginAt: z.string().datetime().nullable(),
+    createdAt: z.string().datetime(),
+  })
+);
+
+// 2. Register Paths
+registry.registerPath({
+  method: 'post',
+  path: '/api/auth/login',
+  summary: 'User Login',
+  request: {
+    body: {
+      content: {
+        'application/json': {
+          schema: z.object({
+            email: z.string().email(),
+            password: z.string(),
+            rememberMe: z.boolean().optional(),
+          }),
+        },
+      },
+    },
+  },
+  responses: {
+    200: {
+      description: 'Successful login',
+      content: {
+        'application/json': {
+          schema: z.object({
+            message: z.string(),
+            user: UserSchema,
+            tokens: z.object({
+              accessToken: z.string(),
+              refreshToken: z.string(),
+            }),
+          }),
+        },
+      },
+    },
+    401: { description: 'Unauthorized', content: { 'application/json': { schema: ErrorSchema } } },
+  },
+});
+
+registry.registerPath({
+  method: 'get',
+  path: '/api/users',
+  summary: 'List Users',
+  security: [{ bearerAuth: [] }],
+  responses: {
+    200: {
+      description: 'List of users',
+      content: {
+        'application/json': {
+          schema: z.object({
+            users: z.array(UserSchema),
+            pagination: z.object({
+              page: z.number(),
+              limit: z.number(),
+              totalUsers: z.number(),
+              totalPages: z.number(),
+            }),
+          }),
+        },
+      },
+    },
+  },
+});
+
+// Security Schemes
+registry.registerComponent('securitySchemes', 'bearerAuth', {
+  type: 'http',
+  scheme: 'bearer',
+  bearerFormat: 'JWT',
+});
+
+// Generator
+const generator = new OpenApiGeneratorV3(registry.definitions);
+
+const spec = generator.generateDocument({
+  openapi: '3.0.0',
+  info: {
+    version: '1.0.0',
+    title: 'SocleStack API',
+    description: 'Enterprise-grade User Management API Specification',
+  },
+  servers: [{ url: '/api' }],
+});
+
+// Output
+const jsonPath = './docs/public/openapi.json';
+const yamlPath = './docs/public/openapi.yaml';
+
+if (!fs.existsSync('./docs/public')) {
+  fs.mkdirSync('./docs/public', { recursive: true });
+}
+
+fs.writeFileSync(jsonPath, JSON.stringify(spec, null, 2));
+fs.writeFileSync(yamlPath, yaml.dump(spec));
+
+console.log('OpenAPI specification generated successfully at:');
+console.log(`- ${jsonPath}`);
+console.log(`- ${yamlPath}`);

--- a/typedoc.json
+++ b/typedoc.json
@@ -1,0 +1,7 @@
+{
+  "entryPoints": ["src/lib/auth.ts", "src/lib/db.ts", "src/lib/security.ts", "src/types/auth.ts"],
+  "out": "docs/api-generated",
+  "plugin": ["typedoc-plugin-markdown"],
+  "theme": "markdown",
+  "hideBreadcrumbs": true
+}


### PR DESCRIPTION
## Summary

- Add `scripts/generate-openapi.ts` for OpenAPI spec generation using zod-to-openapi
- Add `typedoc.json` for TypeDoc configuration
- Add `docs:*` npm scripts to package.json (`docs:dev`, `docs:build`, `docs:preview`, `docs:typedoc`, `docs:openapi`, `docs:all`)
- Add required devDependencies for documentation tools

## Test plan

- [ ] Run `npm install` to install new dependencies
- [ ] Run `npm run docs:typedoc` to verify TypeDoc generation
- [ ] Run `npm run docs:openapi` to verify OpenAPI spec generation
- [ ] Run `npm run docs:build` to verify full docs build

Closes #2
Closes #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)