### PR TITLE
fix: improve docs CI reliability

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -37,7 +37,7 @@ jobs:
           node-version: 20
           cache: 'npm'
       - name: Install dependencies
-        run: npm install
+        run: npm ci
       - name: Build with VitePress
         run: npm run docs:build
       - name: Setup Pages


### PR DESCRIPTION
## Summary

- Use `npm ci` instead of `npm install` in GitHub Actions for reproducible builds

## Note on Issue #5

Issue #5 (dead link detection) is deferred - the docs have 8 broken internal links that need to be fixed first. See Issue #10.

## Test plan

- [ ] Verify GitHub Actions workflow runs successfully

Closes #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)