### PR TITLE
ci: add docs build verification for pull requests

### DIFF
--- a/.github/workflows/docs-build-check.yml
+++ b/.github/workflows/docs-build-check.yml
@@ -10,10 +10,12 @@ on:
       - 'package-lock.json'
       - 'typedoc.json'
       - 'tsconfig.json'
+      - '.github/workflows/docs-build-check.yml'
 
 jobs:
   build:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
## Summary

- Adds new GitHub Actions workflow that verifies documentation builds successfully on PRs
- Triggers on changes to docs, source code, and configuration files

## Changes

- New `.github/workflows/docs-build-check.yml` workflow that:
  - Runs on PRs modifying `docs/**`, `src/**`, `package.json`, `typedoc.json`, or `tsconfig.json`
  - Installs dependencies with `npm ci`
  - Runs `npm run docs:build` to verify the build succeeds

## Benefits

- Catch documentation build failures before merge
- Validate TypeDoc generation works correctly
- Ensure VitePress builds without errors

Closes #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)