### PR TITLE
fix(auth): use SECURITY_CONFIG for cleanup interval

### DIFF
--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -15,6 +15,7 @@ import {
 import { User, ApiKeyPermission, Role } from '@prisma/client';
 import { validateApiKey, isMethodAllowed } from './api-keys';
 import { log } from './logger';
+import { SECURITY_CONFIG } from './config/security';
 
 // ============================================================================
 // Session Configuration
@@ -465,8 +466,7 @@ export function startRateLimitCleanup(intervalMs?: number): void {
     return;
   }
 
-  // Import dynamically to avoid circular dependency
-  const interval = intervalMs ?? 60000; // Default 60 seconds
+  const interval = intervalMs ?? SECURITY_CONFIG.rateLimits.cleanupIntervalMs;
 
   cleanupIntervalId = setInterval(() => {
     const now = Date.now();


### PR DESCRIPTION
## Summary
- Use `SECURITY_CONFIG.rateLimits.cleanupIntervalMs` instead of hardcoded `60000` in `startRateLimitCleanup()` function
- Ensures cleanup interval is configurable via centralized security config

Fixes #99

## Test plan
- [x] All 276 unit tests pass
- [x] Build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)