### PR TITLE
fix: suppress React Hook warning in audit-log-viewer

### DIFF
--- a/src/components/admin/audit-log-viewer.tsx
+++ b/src/components/admin/audit-log-viewer.tsx
@@ -191,6 +191,7 @@ export function AuditLogViewer() {
 
   useEffect(() => {
     fetchLogs(1);
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- Intentionally run only on mount; filter changes are applied via handleApplyFilters button
   }, []);
 
   const handleApplyFilters = () => {


### PR DESCRIPTION
## Summary

- Suppresses the React Hook ESLint warning that appeared on every build for `audit-log-viewer.tsx`
- Added eslint-disable comment with explanation of intentional behavior

## Context

The `useEffect` at line 192 is intentionally run only on mount. Filter changes are applied via explicit user action (clicking the "Apply Filters" button via `handleApplyFilters`).

Adding `fetchLogs` to the dependency array would cause unwanted refetches whenever any filter state changes, which is not the desired UX.

## Changes

- Added `// eslint-disable-next-line react-hooks/exhaustive-deps` with explanatory comment

## Test plan

- [x] Build passes with no React Hook warnings
- [x] Pre-commit and pre-push hooks pass

Fixes #139

🤖 Generated with [Claude Code](https://claude.com/claude-code)