### PR TITLE
feat(api): implement GET/POST /api/admin/roles

### DIFF
--- a/src/app/api/admin/roles/route.ts
+++ b/src/app/api/admin/roles/route.ts
@@ -1,0 +1,248 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { z } from 'zod';
+import { getCurrentUser } from '@/lib/auth';
+import { prisma } from '@/lib/db';
+import { isGranted, ROLES, clearRoleHierarchyCache } from '@/lib/security/index';
+import { logAuditEvent } from '@/lib/audit';
+
+export const runtime = 'nodejs';
+
+/**
+ * Validation schema for creating a new role
+ */
+const createRoleSchema = z.object({
+  name: z
+    .string()
+    .min(1, 'Name is required')
+    .regex(
+      /^ROLE_[A-Z][A-Z0-9_]*$/,
+      'Role name must start with ROLE_ and contain only uppercase letters, numbers, and underscores'
+    ),
+  description: z.string().optional(),
+  parentId: z.string().optional(),
+});
+
+/**
+ * GET /api/admin/roles
+ *
+ * List all roles with hierarchy info and user counts.
+ * Requires ROLE_ADMIN access.
+ */
+export async function GET() {
+  try {
+    const user = await getCurrentUser();
+
+    if (!user) {
+      return NextResponse.json(
+        {
+          error: { type: 'AUTHENTICATION_ERROR', message: 'Not authenticated' },
+        },
+        { status: 401 }
+      );
+    }
+
+    if (!(await isGranted(user, ROLES.ADMIN))) {
+      return NextResponse.json(
+        {
+          error: {
+            type: 'AUTHORIZATION_ERROR',
+            message: 'Admin access required',
+          },
+        },
+        { status: 403 }
+      );
+    }
+
+    const roles = await prisma.role.findMany({
+      include: {
+        parent: {
+          select: {
+            id: true,
+            name: true,
+          },
+        },
+        _count: {
+          select: {
+            userRoles: true,
+          },
+        },
+      },
+      orderBy: {
+        name: 'asc',
+      },
+    });
+
+    return NextResponse.json({
+      roles: roles.map((role) => ({
+        id: role.id,
+        name: role.name,
+        description: role.description,
+        parentId: role.parentId,
+        parentName: role.parent?.name ?? null,
+        isSystem: role.isSystem,
+        userCount: role._count.userRoles,
+        createdAt: role.createdAt.toISOString(),
+        updatedAt: role.updatedAt.toISOString(),
+      })),
+    });
+  } catch (error) {
+    console.error('Admin roles list error:', error);
+    return NextResponse.json(
+      {
+        error: {
+          type: 'SERVER_ERROR',
+          message: 'Failed to fetch roles',
+        },
+      },
+      { status: 500 }
+    );
+  }
+}
+
+/**
+ * POST /api/admin/roles
+ *
+ * Create a new role.
+ * Requires ROLE_ADMIN access.
+ */
+export async function POST(req: NextRequest) {
+  try {
+    const user = await getCurrentUser();
+
+    if (!user) {
+      return NextResponse.json(
+        {
+          error: { type: 'AUTHENTICATION_ERROR', message: 'Not authenticated' },
+        },
+        { status: 401 }
+      );
+    }
+
+    if (!(await isGranted(user, ROLES.ADMIN))) {
+      return NextResponse.json(
+        {
+          error: {
+            type: 'AUTHORIZATION_ERROR',
+            message: 'Admin access required',
+          },
+        },
+        { status: 403 }
+      );
+    }
+
+    const body = await req.json();
+    const parseResult = createRoleSchema.safeParse(body);
+
+    if (!parseResult.success) {
+      return NextResponse.json(
+        {
+          error: {
+            type: 'VALIDATION_ERROR',
+            message: 'Invalid input',
+            details: parseResult.error.flatten().fieldErrors,
+          },
+        },
+        { status: 400 }
+      );
+    }
+
+    const { name, description, parentId } = parseResult.data;
+
+    // Check for duplicate name
+    const existingRole = await prisma.role.findUnique({
+      where: { name },
+    });
+
+    if (existingRole) {
+      return NextResponse.json(
+        {
+          error: {
+            type: 'VALIDATION_ERROR',
+            message: 'Role name already exists',
+          },
+        },
+        { status: 409 }
+      );
+    }
+
+    // Validate parent exists if provided
+    if (parentId) {
+      const parentRole = await prisma.role.findUnique({
+        where: { id: parentId },
+      });
+
+      if (!parentRole) {
+        return NextResponse.json(
+          {
+            error: {
+              type: 'VALIDATION_ERROR',
+              message: 'Parent role not found',
+            },
+          },
+          { status: 400 }
+        );
+      }
+    }
+
+    // Create the role
+    const role = await prisma.role.create({
+      data: {
+        name,
+        description: description ?? null,
+        parentId: parentId ?? null,
+        isSystem: false,
+      },
+      include: {
+        parent: {
+          select: {
+            id: true,
+            name: true,
+          },
+        },
+      },
+    });
+
+    // Clear role hierarchy cache since we added a new role
+    clearRoleHierarchyCache();
+
+    // Audit log
+    await logAuditEvent({
+      action: 'ADMIN_ROLE_CREATED',
+      category: 'admin',
+      userId: user.id,
+      metadata: {
+        roleId: role.id,
+        roleName: role.name,
+        parentId: role.parentId,
+      },
+    });
+
+    return NextResponse.json(
+      {
+        role: {
+          id: role.id,
+          name: role.name,
+          description: role.description,
+          parentId: role.parentId,
+          parentName: role.parent?.name ?? null,
+          isSystem: role.isSystem,
+          userCount: 0,
+          createdAt: role.createdAt.toISOString(),
+          updatedAt: role.updatedAt.toISOString(),
+        },
+      },
+      { status: 201 }
+    );
+  } catch (error) {
+    console.error('Admin role create error:', error);
+    return NextResponse.json(
+      {
+        error: {
+          type: 'SERVER_ERROR',
+          message: 'Failed to create role',
+        },
+      },
+      { status: 500 }
+    );
+  }
+}

--- a/src/lib/audit.ts
+++ b/src/lib/audit.ts
@@ -48,7 +48,12 @@ export type AuditAction =
   // Admin Organization Management
   | 'ADMIN_ORG_OWNERSHIP_TRANSFER'
   | 'ADMIN_ORG_MEMBER_REMOVED'
-  | 'ADMIN_ORG_DELETED';
+  | 'ADMIN_ORG_DELETED'
+  // Admin Role Management
+  | 'ADMIN_ROLE_CREATED'
+  | 'ADMIN_ROLE_UPDATED'
+  | 'ADMIN_ROLE_DELETED'
+  | 'ADMIN_USER_ROLES_UPDATED';
 
 export type AuditCategory = 'authentication' | 'security' | 'admin';
 

--- a/tests/unit/admin-roles-api.spec.ts
+++ b/tests/unit/admin-roles-api.spec.ts
@@ -1,0 +1,328 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { NextRequest } from 'next/server';
+import { GET, POST } from '@/app/api/admin/roles/route';
+
+// Mock dependencies
+vi.mock('@/lib/auth', () => ({
+  getCurrentUser: vi.fn(),
+}));
+
+vi.mock('@/lib/db', () => ({
+  prisma: {
+    role: {
+      findMany: vi.fn(),
+      findUnique: vi.fn(),
+      create: vi.fn(),
+    },
+  },
+}));
+
+vi.mock('@/lib/security/index', () => ({
+  isGranted: vi.fn(),
+  ROLES: {
+    ADMIN: 'ROLE_ADMIN',
+    MODERATOR: 'ROLE_MODERATOR',
+    USER: 'ROLE_USER',
+  },
+  clearRoleHierarchyCache: vi.fn(),
+}));
+
+vi.mock('@/lib/audit', () => ({
+  logAuditEvent: vi.fn(),
+}));
+
+import { getCurrentUser } from '@/lib/auth';
+import { prisma } from '@/lib/db';
+import { isGranted, clearRoleHierarchyCache } from '@/lib/security/index';
+import { logAuditEvent } from '@/lib/audit';
+
+describe('Admin Roles API', () => {
+  const mockAdminUser = {
+    id: 'admin-123',
+    email: 'admin@example.com',
+    userRoles: [{ role: { id: 'role-1', name: 'ROLE_ADMIN', parentId: null } }],
+  };
+
+  const mockRoles = [
+    {
+      id: 'role-1',
+      name: 'ROLE_ADMIN',
+      description: 'Full platform administration',
+      parentId: 'role-2',
+      isSystem: true,
+      createdAt: new Date('2024-01-01'),
+      updatedAt: new Date('2024-01-01'),
+      parent: { id: 'role-2', name: 'ROLE_MODERATOR' },
+      _count: { userRoles: 2 },
+    },
+    {
+      id: 'role-2',
+      name: 'ROLE_MODERATOR',
+      description: 'Content moderation',
+      parentId: 'role-3',
+      isSystem: true,
+      createdAt: new Date('2024-01-01'),
+      updatedAt: new Date('2024-01-01'),
+      parent: { id: 'role-3', name: 'ROLE_USER' },
+      _count: { userRoles: 5 },
+    },
+    {
+      id: 'role-3',
+      name: 'ROLE_USER',
+      description: 'Basic user access',
+      parentId: null,
+      isSystem: true,
+      createdAt: new Date('2024-01-01'),
+      updatedAt: new Date('2024-01-01'),
+      parent: null,
+      _count: { userRoles: 100 },
+    },
+  ];
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('GET /api/admin/roles', () => {
+    it('should return 401 if not authenticated', async () => {
+      vi.mocked(getCurrentUser).mockResolvedValue(null);
+
+      const response = await GET();
+      const data = await response.json();
+
+      expect(response.status).toBe(401);
+      expect(data.error.type).toBe('AUTHENTICATION_ERROR');
+    });
+
+    it('should return 403 if not admin', async () => {
+      vi.mocked(getCurrentUser).mockResolvedValue(mockAdminUser as never);
+      vi.mocked(isGranted).mockResolvedValue(false);
+
+      const response = await GET();
+      const data = await response.json();
+
+      expect(response.status).toBe(403);
+      expect(data.error.type).toBe('AUTHORIZATION_ERROR');
+    });
+
+    it('should return all roles with hierarchy info', async () => {
+      vi.mocked(getCurrentUser).mockResolvedValue(mockAdminUser as never);
+      vi.mocked(isGranted).mockResolvedValue(true);
+      vi.mocked(prisma.role.findMany).mockResolvedValue(mockRoles as never);
+
+      const response = await GET();
+      const data = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(data.roles).toHaveLength(3);
+      expect(data.roles[0]).toEqual({
+        id: 'role-1',
+        name: 'ROLE_ADMIN',
+        description: 'Full platform administration',
+        parentId: 'role-2',
+        parentName: 'ROLE_MODERATOR',
+        isSystem: true,
+        userCount: 2,
+        createdAt: expect.any(String),
+        updatedAt: expect.any(String),
+      });
+    });
+
+    it('should handle roles without parent', async () => {
+      vi.mocked(getCurrentUser).mockResolvedValue(mockAdminUser as never);
+      vi.mocked(isGranted).mockResolvedValue(true);
+      vi.mocked(prisma.role.findMany).mockResolvedValue([mockRoles[2]] as never);
+
+      const response = await GET();
+      const data = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(data.roles[0].parentId).toBeNull();
+      expect(data.roles[0].parentName).toBeNull();
+    });
+  });
+
+  describe('POST /api/admin/roles', () => {
+    const createRequest = (body: object) =>
+      new NextRequest('http://localhost/api/admin/roles', {
+        method: 'POST',
+        body: JSON.stringify(body),
+      });
+
+    it('should return 401 if not authenticated', async () => {
+      vi.mocked(getCurrentUser).mockResolvedValue(null);
+
+      const response = await POST(createRequest({ name: 'ROLE_TEST' }));
+      const data = await response.json();
+
+      expect(response.status).toBe(401);
+      expect(data.error.type).toBe('AUTHENTICATION_ERROR');
+    });
+
+    it('should return 403 if not admin', async () => {
+      vi.mocked(getCurrentUser).mockResolvedValue(mockAdminUser as never);
+      vi.mocked(isGranted).mockResolvedValue(false);
+
+      const response = await POST(createRequest({ name: 'ROLE_TEST' }));
+      const data = await response.json();
+
+      expect(response.status).toBe(403);
+      expect(data.error.type).toBe('AUTHORIZATION_ERROR');
+    });
+
+    it('should validate role name format', async () => {
+      vi.mocked(getCurrentUser).mockResolvedValue(mockAdminUser as never);
+      vi.mocked(isGranted).mockResolvedValue(true);
+
+      // Invalid: doesn't start with ROLE_
+      const response1 = await POST(createRequest({ name: 'ADMIN' }));
+      expect(response1.status).toBe(400);
+
+      // Invalid: lowercase
+      const response2 = await POST(createRequest({ name: 'ROLE_admin' }));
+      expect(response2.status).toBe(400);
+
+      // Invalid: special characters
+      const response3 = await POST(createRequest({ name: 'ROLE_ADMIN-TEST' }));
+      expect(response3.status).toBe(400);
+    });
+
+    it('should reject duplicate role names', async () => {
+      vi.mocked(getCurrentUser).mockResolvedValue(mockAdminUser as never);
+      vi.mocked(isGranted).mockResolvedValue(true);
+      vi.mocked(prisma.role.findUnique).mockResolvedValue(mockRoles[0] as never);
+
+      const response = await POST(createRequest({ name: 'ROLE_ADMIN' }));
+      const data = await response.json();
+
+      expect(response.status).toBe(409);
+      expect(data.error.message).toBe('Role name already exists');
+    });
+
+    it('should validate parent role exists', async () => {
+      vi.mocked(getCurrentUser).mockResolvedValue(mockAdminUser as never);
+      vi.mocked(isGranted).mockResolvedValue(true);
+      vi.mocked(prisma.role.findUnique)
+        .mockResolvedValueOnce(null) // No duplicate
+        .mockResolvedValueOnce(null); // Parent not found
+
+      const response = await POST(
+        createRequest({ name: 'ROLE_NEW', parentId: 'invalid-id' })
+      );
+      const data = await response.json();
+
+      expect(response.status).toBe(400);
+      expect(data.error.message).toBe('Parent role not found');
+    });
+
+    it('should create role successfully', async () => {
+      vi.mocked(getCurrentUser).mockResolvedValue(mockAdminUser as never);
+      vi.mocked(isGranted).mockResolvedValue(true);
+      vi.mocked(prisma.role.findUnique)
+        .mockResolvedValueOnce(null) // No duplicate
+        .mockResolvedValueOnce(mockRoles[2] as never); // Parent exists
+
+      const newRole = {
+        id: 'new-role-id',
+        name: 'ROLE_SUPPORT',
+        description: 'Support team',
+        parentId: 'role-3',
+        isSystem: false,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+        parent: { id: 'role-3', name: 'ROLE_USER' },
+      };
+
+      vi.mocked(prisma.role.create).mockResolvedValue(newRole as never);
+
+      const response = await POST(
+        createRequest({
+          name: 'ROLE_SUPPORT',
+          description: 'Support team',
+          parentId: 'role-3',
+        })
+      );
+      const data = await response.json();
+
+      expect(response.status).toBe(201);
+      expect(data.role.name).toBe('ROLE_SUPPORT');
+      expect(data.role.parentName).toBe('ROLE_USER');
+      expect(data.role.isSystem).toBe(false);
+      expect(data.role.userCount).toBe(0);
+    });
+
+    it('should clear role hierarchy cache after creation', async () => {
+      vi.mocked(getCurrentUser).mockResolvedValue(mockAdminUser as never);
+      vi.mocked(isGranted).mockResolvedValue(true);
+      vi.mocked(prisma.role.findUnique).mockResolvedValue(null);
+      vi.mocked(prisma.role.create).mockResolvedValue({
+        id: 'new-role',
+        name: 'ROLE_NEW',
+        description: null,
+        parentId: null,
+        isSystem: false,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+        parent: null,
+      } as never);
+
+      await POST(createRequest({ name: 'ROLE_NEW' }));
+
+      expect(clearRoleHierarchyCache).toHaveBeenCalled();
+    });
+
+    it('should log audit event on creation', async () => {
+      vi.mocked(getCurrentUser).mockResolvedValue(mockAdminUser as never);
+      vi.mocked(isGranted).mockResolvedValue(true);
+      vi.mocked(prisma.role.findUnique).mockResolvedValue(null);
+      vi.mocked(prisma.role.create).mockResolvedValue({
+        id: 'new-role',
+        name: 'ROLE_NEW',
+        description: null,
+        parentId: null,
+        isSystem: false,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+        parent: null,
+      } as never);
+
+      await POST(createRequest({ name: 'ROLE_NEW' }));
+
+      expect(logAuditEvent).toHaveBeenCalledWith({
+        action: 'ADMIN_ROLE_CREATED',
+        category: 'admin',
+        userId: 'admin-123',
+        metadata: {
+          roleId: 'new-role',
+          roleName: 'ROLE_NEW',
+          parentId: null,
+        },
+      });
+    });
+
+    it('should create role without parent', async () => {
+      vi.mocked(getCurrentUser).mockResolvedValue(mockAdminUser as never);
+      vi.mocked(isGranted).mockResolvedValue(true);
+      vi.mocked(prisma.role.findUnique).mockResolvedValue(null);
+      vi.mocked(prisma.role.create).mockResolvedValue({
+        id: 'new-role',
+        name: 'ROLE_STANDALONE',
+        description: 'Standalone role',
+        parentId: null,
+        isSystem: false,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+        parent: null,
+      } as never);
+
+      const response = await POST(
+        createRequest({ name: 'ROLE_STANDALONE', description: 'Standalone role' })
+      );
+      const data = await response.json();
+
+      expect(response.status).toBe(201);
+      expect(data.role.parentId).toBeNull();
+      expect(data.role.parentName).toBeNull();
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Add admin API endpoints for role management (GET list, POST create)
- Add audit logging for role management actions
- 13 unit tests covering all scenarios

## Changes
- `src/app/api/admin/roles/route.ts` - GET/POST handlers
- `src/lib/audit.ts` - Add role management audit actions
- `tests/unit/admin-roles-api.spec.ts` - Unit tests

## API

### GET /api/admin/roles
Returns all roles with hierarchy info and user counts.

### POST /api/admin/roles
Create a new role with validation:
- Name must match `ROLE_[A-Z0-9_]+`
- Name must be unique
- Parent role must exist if provided

## Test Coverage
- Authentication (401)
- Authorization (403)
- Role name validation
- Duplicate prevention
- Parent role validation
- Successful creation
- Audit logging
- Cache invalidation

Closes #166

🤖 Generated with [Claude Code](https://claude.com/claude-code)