### PR TITLE
feat(api): implement GET/PUT /api/admin/users/[id]/roles

### DIFF
--- a/src/app/api/admin/users/[id]/roles/route.ts
+++ b/src/app/api/admin/users/[id]/roles/route.ts
@@ -104,7 +104,7 @@ function formatUserRolesResponse(
  * Get user's assigned roles (direct and inherited).
  * Requires ROLE_ADMIN access.
  */
-export async function GET(req: NextRequest, { params }: RouteParams) {
+export async function GET(_req: NextRequest, { params }: RouteParams) {
   try {
     const currentUser = await getCurrentUser();
 


### PR DESCRIPTION
## Summary

Implements Story 4.3 from EPIC #152 (Role Management API).

- GET `/api/admin/users/[id]/roles` - Returns user's direct and inherited roles
- PUT `/api/admin/users/[id]/roles` - Replaces all user roles with validation

## Changes

- Adds `src/app/api/admin/users/[id]/roles/route.ts` with GET and PUT handlers
- Returns both direct roles and inherited roles (via hierarchy) for UI flexibility
- Prevents removing the last ROLE_ADMIN user from the system
- Validates all role IDs exist before update
- Audit logs all role changes with before/after state

## API

### GET /api/admin/users/[id]/roles
Returns:
```json
{
  "userId": "...",
  "email": "...",
  "directRoles": [{ "id": "...", "name": "ROLE_ADMIN", "description": "..." }],
  "inheritedRoles": [{ "id": "...", "name": "ROLE_USER", "description": "..." }]
}
```

### PUT /api/admin/users/[id]/roles
Body: `{ "roleIds": ["role-id-1", "role-id-2"] }`

## Test plan

- [ ] Verify GET returns user roles with inheritance
- [ ] Verify PUT replaces roles correctly
- [ ] Verify cannot remove last admin user
- [ ] Verify audit logging captures role changes

Closes Story 4.3 of #152

🤖 Generated with [Claude Code](https://claude.com/claude-code)