### PR TITLE
feat(api): add childCount to GET /api/admin/roles response

### DIFF
--- a/src/app/api/admin/roles/route.ts
+++ b/src/app/api/admin/roles/route.ts
@@ -68,6 +68,7 @@ export async function GET() {
         _count: {
           select: {
             userRoles: true,
+            children: true,
           },
         },
       },
@@ -85,6 +86,7 @@ export async function GET() {
         parentName: role.parent?.name ?? null,
         isSystem: role.isSystem,
         userCount: role._count.userRoles,
+        childCount: role._count.children,
         createdAt: role.createdAt.toISOString(),
         updatedAt: role.updatedAt.toISOString(),
       })),
@@ -231,6 +233,7 @@ export async function POST(req: NextRequest) {
           parentName: role.parent?.name ?? null,
           isSystem: role.isSystem,
           userCount: 0,
+          childCount: 0,
           createdAt: role.createdAt.toISOString(),
           updatedAt: role.updatedAt.toISOString(),
         },


### PR DESCRIPTION
## Summary

Add `childCount` field to roles list response showing how many child roles inherit from each role.

**Before:**
```json
{ "id": "...", "name": "ROLE_MODERATOR", "userCount": 5 }
```

**After:**
```json
{ "id": "...", "name": "ROLE_MODERATOR", "userCount": 5, "childCount": 1 }
```

Closes #190

## Test plan

- [ ] GET /api/admin/roles returns childCount for each role
- [ ] Newly created roles (POST) return childCount: 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)