### PR TITLE
feat(types): update PlatformRole to template literal type

### DIFF
--- a/src/components/admin/user-management.tsx
+++ b/src/components/admin/user-management.tsx
@@ -29,7 +29,7 @@ interface User {
   username?: string;
   firstName?: string;
   lastName?: string;
-  role: 'ROLE_USER' | 'ROLE_MODERATOR' | 'ROLE_ADMIN';
+  role: string;
   isActive: boolean;
   emailVerified: boolean;
   lastLoginAt?: string;

--- a/src/components/navigation/navbar.tsx
+++ b/src/components/navigation/navbar.tsx
@@ -29,7 +29,7 @@ interface User {
   username?: string;
   firstName?: string;
   lastName: string;
-  role: 'ROLE_USER' | 'ROLE_MODERATOR' | 'ROLE_ADMIN';
+  role: string;
   organizationId?: string;
   organizationRole?: 'OWNER' | 'ADMIN' | 'MEMBER';
 }

--- a/src/components/navigation/quick-actions-menu.tsx
+++ b/src/components/navigation/quick-actions-menu.tsx
@@ -20,7 +20,7 @@ import {
 import { ROLES } from '@/lib/security/client';
 
 interface QuickActionsMenuProps {
-  userRole: 'ROLE_USER' | 'ROLE_MODERATOR' | 'ROLE_ADMIN';
+  userRole: string;
   organizationId?: string;
   organizationRole?: 'OWNER' | 'ADMIN' | 'MEMBER';
 }
@@ -55,9 +55,7 @@ const menuItems = [
   },
 ];
 
-function getAdminItems(
-  userRole: 'ROLE_USER' | 'ROLE_MODERATOR' | 'ROLE_ADMIN'
-) {
+function getAdminItems(userRole: string) {
   const baseItems = [
     { label: 'User Management', href: '/admin', icon: UserCog },
     { label: 'Audit Logs', href: '/admin/audit-logs', icon: Activity },

--- a/src/lib/api-utils.ts
+++ b/src/lib/api-utils.ts
@@ -132,4 +132,3 @@ export async function requireAdmin(): Promise<
 
   return { ok: true, user };
 }
-

--- a/src/types/auth.ts
+++ b/src/types/auth.ts
@@ -3,8 +3,11 @@ import { User, OrganizationRole } from '@prisma/client';
 /**
  * Platform role names (stored in roles table)
  * ROLE_ADMIN inherits from ROLE_MODERATOR inherits from ROLE_USER
+ *
+ * Uses template literal type to support arbitrary database-driven roles.
+ * Role names must follow the pattern: ROLE_[A-Z][A-Z0-9_]*
  */
-export type PlatformRole = 'ROLE_USER' | 'ROLE_MODERATOR' | 'ROLE_ADMIN';
+export type PlatformRole = `ROLE_${string}`;
 
 export interface LoginCredentials {
   email: string;


### PR DESCRIPTION
## Summary
- Update `PlatformRole` from union of 3 literals to `ROLE_${string}` template literal type
- Update component interfaces (`navbar`, `quick-actions-menu`, `user-management`) to use string for role properties

Closes #208

## Test plan
- [x] TypeScript compilation passes
- [x] Build succeeds
- [ ] Existing role checks continue to work (uses `ROLES` constants)

🤖 Generated with [Claude Code](https://claude.com/claude-code)