### PR TITLE
chore: remove stale TODO comments referencing #183

### DIFF
--- a/src/lib/security/voters/user-voter.ts
+++ b/src/lib/security/voters/user-voter.ts
@@ -6,10 +6,6 @@
  * @note This voter uses a loose type guard (any object with `id`) intentionally.
  * The voter registry routes requests to the correct voter based on attribute prefix,
  * so OrganizationVoter handles `organization.*` and UserVoter handles `user.*`.
- *
- * @todo ROLES.MODERATOR is hardcoded. When dynamic roles are implemented (see #183),
- * this voter will need to be refactored to use a configurable permission mapping
- * or query role capabilities from the database.
  */
 
 import type { Voter } from '../voter';
@@ -73,7 +69,6 @@ export class UserVoter implements Voter {
     }
 
     // MODERATOR can view/edit other users but not delete or manage roles
-    // TODO: Hardcoded role - see #183 for dynamic role architecture
     if (await hasRole(user, ROLES.MODERATOR)) {
       if (attribute === 'user.view' || attribute === 'user.edit') {
         return VoteResult.GRANTED;


### PR DESCRIPTION
## Summary
- Removed outdated `@todo` JSDoc comment from `user-voter.ts` header
- Removed inline TODO comment about hardcoded roles

Issue #183 (Unified Dynamic Role Architecture) is complete. The `ROLE_NAMES` constants are the intended design, not a temporary workaround.

## Test Plan
- [x] Verified no other #183 references in `src/`
- [x] Lint and type checks pass

Closes #244

🤖 Generated with [Claude Code](https://claude.com/claude-code)