### PR TITLE
refactor: replace hardcoded role strings with ROLES constants

### DIFF
--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -61,7 +61,7 @@ export default async function AdminPage() {
     prisma.user.count({ where: { isActive: true } }),
     prisma.user.count({ where: { lockedUntil: { gt: now } } }),
     prisma.user.count({
-      where: { userRoles: { some: { role: { name: 'ROLE_ADMIN' } } } },
+      where: { userRoles: { some: { role: { name: ROLES.ADMIN } } } },
     }),
     prisma.user.count({ where: { twoFactorEnabled: true } }),
     prisma.auditLog.count({

--- a/src/app/api/admin/audit-logs/export/route.ts
+++ b/src/app/api/admin/audit-logs/export/route.ts
@@ -174,7 +174,7 @@ export async function GET(req: NextRequest) {
       const adminOrgs = user.userRoles.filter(
         (ur) =>
           ur.organizationId &&
-          (ur.role.name === 'ROLE_ADMIN' || ur.role.name === 'ROLE_OWNER')
+          (ur.role.name === ROLES.ADMIN || ur.role.name === ROLES.OWNER)
       );
 
       if (adminOrgs.length === 0) {

--- a/src/app/api/admin/audit-logs/route.ts
+++ b/src/app/api/admin/audit-logs/route.ts
@@ -92,7 +92,7 @@ export async function GET(req: NextRequest) {
       const adminOrgs = user.userRoles.filter(
         (ur) =>
           ur.organizationId &&
-          (ur.role.name === 'ROLE_ADMIN' || ur.role.name === 'ROLE_OWNER')
+          (ur.role.name === ROLES.ADMIN || ur.role.name === ROLES.OWNER)
       );
 
       if (adminOrgs.length === 0) {

--- a/src/app/api/admin/organizations/[id]/members/[userId]/route.ts
+++ b/src/app/api/admin/organizations/[id]/members/[userId]/route.ts
@@ -4,6 +4,7 @@ import { prisma } from '@/lib/db';
 import { logAuditEvent } from '@/lib/audit';
 import { headers } from 'next/headers';
 import { requireAdmin } from '@/lib/api-utils';
+import { ROLES } from '@/lib/security/index';
 
 export const runtime = 'nodejs';
 
@@ -62,7 +63,7 @@ export async function DELETE(req: NextRequest, { params }: RouteParams) {
     }
 
     // Cannot remove owner
-    if (userRole.role.name === 'ROLE_OWNER') {
+    if (userRole.role.name === ROLES.OWNER) {
       return NextResponse.json(
         {
           error: {

--- a/src/app/api/admin/organizations/[id]/route.ts
+++ b/src/app/api/admin/organizations/[id]/route.ts
@@ -4,17 +4,17 @@ import { prisma } from '@/lib/db';
 import { logAuditEvent } from '@/lib/audit';
 import { headers } from 'next/headers';
 import { requireAdmin } from '@/lib/api-utils';
-import { isGranted, PERMISSIONS } from '@/lib/security/index';
+import { isGranted, PERMISSIONS, ROLES } from '@/lib/security/index';
 
 export const runtime = 'nodejs';
 
 // Role priority for sorting: ROLE_OWNER first, then ROLE_ADMIN, then ROLE_MODERATOR, then ROLE_USER
 const ROLE_PRIORITY: Record<string, number> = {
-  ROLE_OWNER: 0,
-  ROLE_ADMIN: 1,
-  ROLE_MODERATOR: 2,
-  ROLE_EDITOR: 3,
-  ROLE_USER: 4,
+  [ROLES.OWNER]: 0,
+  [ROLES.ADMIN]: 1,
+  [ROLES.MODERATOR]: 2,
+  [ROLES.EDITOR]: 3,
+  [ROLES.USER]: 4,
 };
 
 interface RouteParams {
@@ -152,7 +152,7 @@ export async function PATCH(req: NextRequest, { params }: RouteParams) {
         userRoles: {
           where: {
             role: {
-              name: 'ROLE_OWNER',
+              name: ROLES.OWNER,
             },
           },
           include: {
@@ -254,11 +254,11 @@ export async function PATCH(req: NextRequest, { params }: RouteParams) {
 
     // Get ROLE_ADMIN id for demotion
     const adminRole = await prisma.role.findUnique({
-      where: { name: 'ROLE_ADMIN' },
+      where: { name: ROLES.ADMIN },
     });
 
     if (!adminRole) {
-      throw new Error('ROLE_ADMIN not found in database');
+      throw new Error(`${ROLES.ADMIN} not found in database`);
     }
 
     // Transfer ownership in a transaction

--- a/src/app/api/admin/organizations/route.ts
+++ b/src/app/api/admin/organizations/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { prisma } from '@/lib/db';
 import { getCurrentUser } from '@/lib/auth';
 import { requireAdmin } from '@/lib/api-utils';
+import { ROLES } from '@/lib/security/index';
 
 export const runtime = 'nodejs';
 
@@ -61,7 +62,7 @@ export async function GET(req: NextRequest) {
           userRoles: {
             where: {
               role: {
-                name: 'ROLE_OWNER',
+                name: ROLES.OWNER,
               },
             },
             include: {

--- a/src/app/api/auth/oauth/complete/route.ts
+++ b/src/app/api/auth/oauth/complete/route.ts
@@ -7,6 +7,7 @@ import { generateSlug } from '@/lib/organization';
 import { verifyPendingOAuthToken } from '@/lib/auth/oauth';
 import { z } from 'zod';
 import { generateCsrfToken, CSRF_CONFIG } from '@/lib/csrf';
+import { ROLES } from '@/lib/security/index';
 
 const completeOAuthSchema = z
   .object({
@@ -175,11 +176,11 @@ export async function POST(req: NextRequest) {
 
         // Find ROLE_OWNER role
         const ownerRole = await tx.role.findUnique({
-          where: { name: 'ROLE_OWNER' },
+          where: { name: ROLES.OWNER },
         });
 
         if (!ownerRole) {
-          throw new Error('ROLE_OWNER not found in database');
+          throw new Error(`${ROLES.OWNER} not found in database`);
         }
 
         // Create UserRole linking user to organization as owner

--- a/src/app/api/invites/[token]/accept/route.ts
+++ b/src/app/api/invites/[token]/accept/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { prisma } from '@/lib/db';
 import { getSession } from '@/lib/auth';
 import { AuthError } from '@/types/auth';
+import { ROLES } from '@/lib/security/index';
 
 export const runtime = 'nodejs';
 
@@ -148,7 +149,7 @@ export async function POST(req: NextRequest, { params }: RouteParams) {
         id: invite.organization.id,
         name: invite.organization.name,
         slug: invite.organization.slug,
-        role: role?.name || 'ROLE_USER',
+        role: role?.name || ROLES.USER,
       },
     });
   } catch (error) {

--- a/src/app/api/invites/[token]/route.ts
+++ b/src/app/api/invites/[token]/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { prisma } from '@/lib/db';
 import { AuthError } from '@/types/auth';
+import { ROLES } from '@/lib/security/index';
 
 export const runtime = 'nodejs';
 
@@ -71,7 +72,7 @@ export async function GET(req: NextRequest, { params }: RouteParams) {
     return NextResponse.json({
       invite: {
         email: invite.email,
-        role: role?.name || 'ROLE_USER',
+        role: role?.name || ROLES.USER,
         expiresAt: invite.expiresAt,
         organization: invite.organization,
         invitedBy: inviterName,

--- a/src/app/api/organizations/current/invites/[id]/route.ts
+++ b/src/app/api/organizations/current/invites/[id]/route.ts
@@ -2,7 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { prisma } from '@/lib/db';
 import { getSession } from '@/lib/auth';
 import { getCurrentOrganizationId } from '@/lib/organization';
-import { hasRole, userWithRolesInclude } from '@/lib/security/index';
+import { hasRole, userWithRolesInclude, ROLES } from '@/lib/security/index';
 import { AuthError } from '@/types/auth';
 
 export const runtime = 'nodejs';
@@ -61,7 +61,7 @@ export async function DELETE(req: NextRequest, { params }: RouteParams) {
     }
 
     // Check if user has ADMIN or higher role
-    if (!(await hasRole(user, 'ROLE_ADMIN', organizationId))) {
+    if (!(await hasRole(user, ROLES.ADMIN, organizationId))) {
       return NextResponse.json(
         {
           error: {

--- a/src/app/api/organizations/current/invites/route.ts
+++ b/src/app/api/organizations/current/invites/route.ts
@@ -9,13 +9,13 @@ import {
 } from '@/lib/organization';
 import { AuthError } from '@/types/auth';
 import { sendEmail, organizationInviteTemplate } from '@/lib/email';
-import { hasRole, userWithRolesInclude } from '@/lib/security/index';
+import { hasRole, userWithRolesInclude, ROLES } from '@/lib/security/index';
 
 export const runtime = 'nodejs';
 
 const createInviteSchema = z.object({
   email: z.string().email('Please enter a valid email address'),
-  roleName: z.string().startsWith('ROLE_').default('ROLE_USER'),
+  roleName: z.string().startsWith('ROLE_').default(ROLES.USER),
 });
 
 // GET /api/organizations/current/invites - List pending invites (ADMIN+)
@@ -67,7 +67,7 @@ export async function GET() {
     }
 
     // Check if user has ADMIN or higher role in this organization
-    if (!(await hasRole(user, 'ROLE_ADMIN', organizationId))) {
+    if (!(await hasRole(user, ROLES.ADMIN, organizationId))) {
       return NextResponse.json(
         {
           error: {
@@ -111,7 +111,7 @@ export async function GET() {
     // Transform roleId to role names for response
     const transformedInvites = invites.map((inv) => ({
       ...inv,
-      role: roleMap.get(inv.roleId) || 'ROLE_USER',
+      role: roleMap.get(inv.roleId) || ROLES.USER,
       roleId: undefined, // Remove roleId from response
     }));
 
@@ -203,7 +203,7 @@ export async function POST(req: NextRequest) {
     }
 
     // Check if user has ADMIN or higher role
-    if (!(await hasRole(user, 'ROLE_ADMIN', organizationId))) {
+    if (!(await hasRole(user, ROLES.ADMIN, organizationId))) {
       return NextResponse.json(
         {
           error: {
@@ -256,7 +256,7 @@ export async function POST(req: NextRequest) {
       // User has this role or higher, which means they can invite
       // But we need to prevent inviting with same or higher role
       // For now, simplified: only allow inviting ROLE_USER and ROLE_MODERATOR if you're ADMIN+
-      if (roleName === 'ROLE_ADMIN' || roleName === 'ROLE_OWNER') {
+      if (roleName === ROLES.ADMIN || roleName === ROLES.OWNER) {
         return NextResponse.json(
           {
             error: {

--- a/src/app/api/organizations/current/route.ts
+++ b/src/app/api/organizations/current/route.ts
@@ -96,7 +96,7 @@ export async function GET() {
         name: organization.name,
         slug: organization.slug,
         memberCount,
-        role: userRole?.role.name || 'ROLE_USER',
+        role: userRole?.role.name || ROLES.USER,
         createdAt: organization.createdAt,
       },
     });
@@ -220,7 +220,7 @@ export async function PATCH(req: NextRequest) {
         id: updatedOrg.id,
         name: updatedOrg.name,
         slug: updatedOrg.slug,
-        role: userRole?.role.name || 'ROLE_USER',
+        role: userRole?.role.name || ROLES.USER,
       },
     });
   } catch (error) {

--- a/src/app/api/organizations/route.ts
+++ b/src/app/api/organizations/route.ts
@@ -4,6 +4,7 @@ import { prisma } from '@/lib/db';
 import { getSession } from '@/lib/auth';
 import { generateSlug } from '@/lib/organization';
 import { AuthError } from '@/types/auth';
+import { ROLES } from '@/lib/security/index';
 
 export const runtime = 'nodejs';
 
@@ -78,11 +79,11 @@ export async function POST(req: NextRequest) {
 
       // Get OWNER role
       const ownerRole = await tx.role.findUnique({
-        where: { name: 'ROLE_OWNER' },
+        where: { name: ROLES.OWNER },
       });
 
       if (!ownerRole) {
-        throw new Error('ROLE_OWNER not found in database');
+        throw new Error(`${ROLES.OWNER} not found in database`);
       }
 
       // Create UserRole record

--- a/src/app/api/users/[id]/route.ts
+++ b/src/app/api/users/[id]/route.ts
@@ -6,7 +6,7 @@ import {
 } from '@/lib/validations';
 import { prisma } from '@/lib/db';
 import { AuthError } from '@/types/auth';
-import { getHighestRole, userWithRolesInclude } from '@/lib/security/index';
+import { getHighestRole, userWithRolesInclude, ROLES } from '@/lib/security/index';
 
 export const runtime = 'nodejs';
 
@@ -108,10 +108,10 @@ export async function GET(req: NextRequest, { params }: RouteParams) {
     // Check if auth user has MODERATOR+ role in any organization
     const hasModerator = authUserFull.userRoles.some((ur) =>
       [
-        'ROLE_MODERATOR',
-        'ROLE_ADMIN',
-        'ROLE_OWNER',
-        'ROLE_PLATFORM_ADMIN',
+        ROLES.MODERATOR,
+        ROLES.ADMIN,
+        ROLES.OWNER,
+        'ROLE_PLATFORM_ADMIN', // Keep as string - not in standard ROLES
       ].includes(ur.role.name)
     );
 
@@ -131,10 +131,10 @@ export async function GET(req: NextRequest, { params }: RouteParams) {
     const authOrgIds = authUserFull.userRoles
       .filter((ur) =>
         [
-          'ROLE_MODERATOR',
-          'ROLE_ADMIN',
-          'ROLE_OWNER',
-          'ROLE_PLATFORM_ADMIN',
+          ROLES.MODERATOR,
+          ROLES.ADMIN,
+          ROLES.OWNER,
+          'ROLE_PLATFORM_ADMIN', // Keep as string - not in standard ROLES
         ].includes(ur.role.name)
       )
       .map((ur) => ur.organizationId)
@@ -144,7 +144,7 @@ export async function GET(req: NextRequest, { params }: RouteParams) {
     const hasPlatformAccess = authUserFull.userRoles.some(
       (ur) =>
         ur.organizationId === null &&
-        ['ROLE_ADMIN', 'ROLE_PLATFORM_ADMIN'].includes(ur.role.name)
+        [ROLES.ADMIN, 'ROLE_PLATFORM_ADMIN'].includes(ur.role.name)
     );
 
     const targetUserOrgIds = user.userRoles
@@ -254,7 +254,7 @@ export async function PATCH(req: NextRequest, { params }: RouteParams) {
     if ('role' in body) {
       // Only admins can change roles
       const hasAdmin = authUser.userRoles.some((ur) =>
-        ['ROLE_ADMIN', 'ROLE_OWNER', 'ROLE_PLATFORM_ADMIN'].includes(
+        [ROLES.ADMIN, ROLES.OWNER, 'ROLE_PLATFORM_ADMIN'].includes(
           ur.role.name
         )
       );
@@ -361,7 +361,7 @@ export async function PATCH(req: NextRequest, { params }: RouteParams) {
     if ('isActive' in body) {
       // Only admins can change user status
       const hasAdmin = authUser.userRoles.some((ur) =>
-        ['ROLE_ADMIN', 'ROLE_OWNER', 'ROLE_PLATFORM_ADMIN'].includes(
+        [ROLES.ADMIN, ROLES.OWNER, 'ROLE_PLATFORM_ADMIN'].includes(
           ur.role.name
         )
       );
@@ -513,7 +513,7 @@ export async function DELETE(req: NextRequest, { params }: RouteParams) {
 
     // Only admins can delete users
     const hasAdmin = authUser.userRoles.some((ur) =>
-      ['ROLE_ADMIN', 'ROLE_OWNER', 'ROLE_PLATFORM_ADMIN'].includes(ur.role.name)
+      [ROLES.ADMIN, ROLES.OWNER, 'ROLE_PLATFORM_ADMIN'].includes(ur.role.name)
     );
 
     if (!hasAdmin) {

--- a/src/app/api/users/delete-account/route.ts
+++ b/src/app/api/users/delete-account/route.ts
@@ -110,7 +110,7 @@ export async function POST(req: NextRequest) {
 
     // Organization owners must transfer ownership first
     const hasOwnerRole = user.userRoles.some(
-      (ur) => ur.organizationId !== null && ur.role.name === 'ROLE_OWNER'
+      (ur) => ur.organizationId !== null && ur.role.name === ROLES.OWNER
     );
 
     if (hasOwnerRole) {

--- a/src/app/api/users/route.ts
+++ b/src/app/api/users/route.ts
@@ -4,7 +4,7 @@ import { userListParamsSchema } from '@/lib/validations';
 import { prisma } from '@/lib/db';
 import { AuthError } from '@/types/auth';
 import { Prisma } from '@prisma/client';
-import { getHighestRole, userWithRolesInclude } from '@/lib/security/index';
+import { getHighestRole, userWithRolesInclude, ROLES } from '@/lib/security/index';
 
 export const runtime = 'nodejs';
 
@@ -51,10 +51,10 @@ export async function GET(req: NextRequest) {
     // Check authorization - user must have MODERATOR+ role in any organization or platform-wide
     const hasModerator = user.userRoles.some((ur) =>
       [
-        'ROLE_MODERATOR',
-        'ROLE_ADMIN',
-        'ROLE_OWNER',
-        'ROLE_PLATFORM_ADMIN',
+        ROLES.MODERATOR,
+        ROLES.ADMIN,
+        ROLES.OWNER,
+        'ROLE_PLATFORM_ADMIN', // Keep as string - not in standard ROLES
       ].includes(ur.role.name)
     );
 
@@ -98,7 +98,7 @@ export async function GET(req: NextRequest) {
 
     // Check if user is platform admin (has ADMIN role with no organization)
     const isPlatformAdmin = user.userRoles.some(
-      (ur) => ur.organizationId === null && ur.role.name === 'ROLE_ADMIN'
+      (ur) => ur.organizationId === null && ur.role.name === ROLES.ADMIN
     );
 
     // If not platform admin, get organization IDs where user is admin
@@ -108,7 +108,7 @@ export async function GET(req: NextRequest) {
           .filter(
             (ur) =>
               ur.organizationId !== null &&
-              (ur.role.name === 'ROLE_ADMIN' || ur.role.name === 'ROLE_OWNER')
+              (ur.role.name === ROLES.ADMIN || ur.role.name === ROLES.OWNER)
           )
           .map((ur) => ur.organizationId as string);
 

--- a/src/components/admin/user-role-select.tsx
+++ b/src/components/admin/user-role-select.tsx
@@ -6,6 +6,7 @@ import { Alert } from '@/components/ui/alert';
 import { Badge } from '@/components/ui/badge';
 import { X, Loader2, Shield, Info } from 'lucide-react';
 import { apiPut } from '@/lib/api-client';
+import { ROLES } from '@/lib/security/client';
 
 interface Role {
   id: string;
@@ -232,7 +233,7 @@ export function UserRoleSelect({
   if (!isOpen) return null;
 
   // Find admin role for self-protection
-  const adminRole = allRoles.find((r) => r.name === 'ROLE_ADMIN');
+  const adminRole = allRoles.find((r) => r.name === ROLES.ADMIN);
   const isRemovingOwnAdminRole =
     isEditingSelf &&
     adminRole &&
@@ -308,7 +309,7 @@ export function UserRoleSelect({
                       inheritedRoles
                     );
                     const isSelected = directRoleIds.has(role.id);
-                    const isAdminRole = role.name === 'ROLE_ADMIN';
+                    const isAdminRole = role.name === ROLES.ADMIN;
 
                     // Disable admin checkbox if editing self and would remove admin role
                     const isDisabledByProtection =

--- a/src/lib/api-utils.ts
+++ b/src/lib/api-utils.ts
@@ -147,7 +147,7 @@ export async function requireAdmin(
 
   // Direct role check pattern (with user argument)
   if (!user) return false;
-  return hasRole(user, 'ROLE_ADMIN', organizationId);
+  return hasRole(user, ROLES.ADMIN, organizationId);
 }
 
 /**
@@ -162,5 +162,5 @@ export async function requireModerator(
   organizationId?: string | null
 ): Promise<boolean> {
   if (!user) return false;
-  return hasRole(user, 'ROLE_MODERATOR', organizationId);
+  return hasRole(user, ROLES.MODERATOR, organizationId);
 }

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -15,6 +15,7 @@ import { User, ApiKeyPermission } from '@prisma/client';
 import {
   userWithRolesInclude,
   getHighestRole,
+  ROLES,
   type UserWithRoles,
   type UserWithComputedRole,
 } from './security/index';
@@ -95,7 +96,7 @@ interface EdgeMockResponse {
 export const EMPTY_SESSION: SessionData = {
   userId: '',
   email: '',
-  role: 'ROLE_USER',
+  role: ROLES.USER,
   isLoggedIn: false,
 };
 

--- a/src/services/auth.service.ts
+++ b/src/services/auth.service.ts
@@ -11,6 +11,7 @@ import {
   requestPasswordResetSchema,
   resetPasswordSchema,
 } from '@/lib/validations';
+import { ROLES } from '@/lib/security/index';
 import { authenticateUser, createUserSession } from '@/lib/auth';
 import { getRateLimiter } from '@/lib/rate-limiter';
 import {
@@ -75,12 +76,12 @@ function getUserRole(user: any): PlatformRole {
     const roleNames = user.userRoles.map(
       (ur: { role: { name: string } }) => ur.role.name
     );
-    if (roleNames.includes('ROLE_ADMIN')) return 'ROLE_ADMIN';
-    if (roleNames.includes('ROLE_MODERATOR')) return 'ROLE_MODERATOR';
-    return 'ROLE_USER';
+    if (roleNames.includes(ROLES.ADMIN)) return ROLES.ADMIN;
+    if (roleNames.includes(ROLES.MODERATOR)) return ROLES.MODERATOR;
+    return ROLES.USER;
   }
   // Default to USER
-  return 'ROLE_USER';
+  return ROLES.USER;
 }
 
 // ============================================================================
@@ -495,10 +496,10 @@ export async function register(
 
       // Get ROLE_OWNER
       const ownerRole = await tx.role.findUnique({
-        where: { name: 'ROLE_OWNER' },
+        where: { name: ROLES.OWNER },
       });
       if (!ownerRole) {
-        throw new Error('ROLE_OWNER not found');
+        throw new Error(`${ROLES.OWNER} not found`);
       }
 
       // Create UserRole with ROLE_OWNER for this organization
@@ -879,7 +880,7 @@ export async function disable2FA(
   }
 
   // Admins cannot disable their own 2FA
-  if (getUserRole(user) === 'ROLE_ADMIN') {
+  if (getUserRole(user) === ROLES.ADMIN) {
     throw new AuthorizationError('Admins cannot disable 2FA');
   }
 

--- a/tests/fixtures/auth/admin-auth.json
+++ b/tests/fixtures/auth/admin-auth.json
@@ -1,0 +1,1 @@
+{"cookies":[],"origins":[]}

--- a/tests/fixtures/auth/user-auth.json
+++ b/tests/fixtures/auth/user-auth.json
@@ -1,0 +1,1 @@
+{"cookies":[],"origins":[]}

--- a/tests/unit/api-utils.spec.ts
+++ b/tests/unit/api-utils.spec.ts
@@ -12,6 +12,14 @@ import {
 // Mock the security module for role helper tests
 vi.mock('@/lib/security/index', () => ({
   hasRole: vi.fn(),
+  isGranted: vi.fn(),
+  ROLES: {
+    ADMIN: 'ROLE_ADMIN',
+    MODERATOR: 'ROLE_MODERATOR',
+    USER: 'ROLE_USER',
+    OWNER: 'ROLE_OWNER',
+    EDITOR: 'ROLE_EDITOR',
+  },
 }));
 
 import { hasRole } from '@/lib/security/index';


### PR DESCRIPTION
## Summary
- Replace all hardcoded role string literals (`'ROLE_ADMIN'`, `'ROLE_USER'`, etc.) with `ROLES` constants from `@/lib/security/index`
- Update auth service, API routes, and components to use centralized role names
- Fix test mock to export ROLES constant

This ensures type-safe role references and prevents frontend/backend drift by using a single source of truth for role names.

## Changes
- 20 production files updated to import and use `ROLES` constant
- 1 test file updated with ROLES in mock
- `ROLE_PLATFORM_ADMIN` preserved as string literal (not in standard ROLES)

## Test plan
- [x] Build passes
- [x] Unit tests pass (588 passed, 26 pre-existing failures in voter-registry.spec.ts)
- [x] All modified files use ROLES constant consistently

Closes #230

🤖 Generated with [Claude Code](https://claude.com/claude-code)