### PR TITLE
refactor(security): minor permission registry improvements

### DIFF
--- a/src/lib/security/permissions.ts
+++ b/src/lib/security/permissions.ts
@@ -70,6 +70,14 @@ export const USER_PERMISSIONS = [
   PERMISSIONS.USER.ROLES.MANAGE,
 ] as const;
 
+/**
+ * All permissions combined for iteration
+ */
+export const ALL_PERMISSIONS = [
+  ...ORGANIZATION_PERMISSIONS,
+  ...USER_PERMISSIONS,
+] as const;
+
 export type OrganizationPermission = (typeof ORGANIZATION_PERMISSIONS)[number];
 export type UserPermission = (typeof USER_PERMISSIONS)[number];
 

--- a/src/lib/security/voters/organization-voter.ts
+++ b/src/lib/security/voters/organization-voter.ts
@@ -60,10 +60,12 @@ export class OrganizationVoter implements Voter {
       return VoteResult.GRANTED;
     }
 
-    const requiredRole = REQUIRED_ROLES[attribute as OrganizationPermission];
-    if (!requiredRole) {
+    // Use type guard to narrow attribute type (supports() already validated this)
+    if (!isOrganizationPermission(attribute)) {
       return VoteResult.ABSTAIN;
     }
+
+    const requiredRole = REQUIRED_ROLES[attribute];
 
     // Check if user has the required role in this specific organization
     const hasRequiredRole = await hasRole(user, requiredRole, org.id);


### PR DESCRIPTION
## Summary
- Eliminate type cast in `organization-voter.ts` `vote()` method by using `isOrganizationPermission` type guard to properly narrow the attribute type
- Add `ALL_PERMISSIONS` export to `permissions.ts` for cases where iteration over all permissions is needed

## Changes
1. **organization-voter.ts**: Replace `attribute as OrganizationPermission` cast with proper type guard check
2. **permissions.ts**: Add `ALL_PERMISSIONS` array combining all permission types

## Test Plan
- [x] Run `npm run test:unit` - all 617 tests pass
- [x] Run `npm run build` - builds successfully

Fixes #251

🤖 Generated with [Claude Code](https://claude.com/claude-code)