### PR TITLE
feat(security): add cache hit/miss monitoring for role hierarchy cache

### DIFF
--- a/src/lib/security/index.ts
+++ b/src/lib/security/index.ts
@@ -16,7 +16,10 @@ import { ROLE_NAMES } from '@/lib/constants/roles';
 import {
   hasRole,
   clearRoleHierarchyCache,
+  getCacheMetrics,
+  resetCacheMetrics,
   type UserWithRoles,
+  type CacheMetrics,
 } from './role-checker';
 import type { Permission } from './permissions';
 
@@ -136,8 +139,9 @@ export async function isGranted(
   return false;
 }
 
-// Re-export hasRole and clearRoleHierarchyCache for backward compatibility
-export { hasRole, clearRoleHierarchyCache };
+// Re-export hasRole, cache management, and metrics functions
+export { hasRole, clearRoleHierarchyCache, getCacheMetrics, resetCacheMetrics };
+export type { CacheMetrics };
 
 /**
  * Clear voter lookup cache (call if voters are dynamically modified)

--- a/src/lib/security/role-checker.ts
+++ b/src/lib/security/role-checker.ts
@@ -212,11 +212,18 @@ export function clearRoleHierarchyCache(): void {
  * Returns hit rate, miss rate, size, and timing information.
  * Use for monitoring cache effectiveness.
  */
-export function getCacheMetrics(): CacheMetrics & { hitRate: number } {
+export function getCacheMetrics(): CacheMetrics & {
+  hitRate: number;
+  missRate: number;
+  totalRequests: number;
+} {
   const total = cacheMetrics.hits + cacheMetrics.misses;
+  const hitRate = total > 0 ? cacheMetrics.hits / total : 0;
   return {
     ...cacheMetrics,
-    hitRate: total > 0 ? cacheMetrics.hits / total : 0,
+    hitRate,
+    missRate: total > 0 ? 1 - hitRate : 0,
+    totalRequests: total,
   };
 }
 

--- a/tests/unit/cache-metrics.spec.ts
+++ b/tests/unit/cache-metrics.spec.ts
@@ -32,6 +32,8 @@ describe('Cache Metrics', () => {
       expect(metrics.misses).toBe(0);
       expect(metrics.size).toBe(0);
       expect(metrics.hitRate).toBe(0);
+      expect(metrics.missRate).toBe(0);
+      expect(metrics.totalRequests).toBe(0);
       expect(metrics.lastWarmTimeMs).toBeNull();
       expect(metrics.lastWarmAt).toBeNull();
     });
@@ -155,7 +157,9 @@ describe('Cache Metrics', () => {
       const metrics = getCacheMetrics();
       expect(metrics.misses).toBe(1);
       expect(metrics.hits).toBe(4);
-      expect(metrics.hitRate).toBe(0.8);
+      expect(metrics.hitRate).toBeCloseTo(0.8);
+      expect(metrics.missRate).toBeCloseTo(0.2);
+      expect(metrics.totalRequests).toBe(5);
     });
   });
 

--- a/tests/unit/cache-metrics.spec.ts
+++ b/tests/unit/cache-metrics.spec.ts
@@ -1,0 +1,262 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import {
+  hasRole,
+  clearRoleHierarchyCache,
+  getCacheMetrics,
+  resetCacheMetrics,
+} from '@/lib/security/role-checker';
+
+// Mock prisma
+vi.mock('@/lib/db', () => ({
+  prisma: {
+    role: {
+      findMany: vi.fn(),
+    },
+  },
+}));
+
+import { prisma } from '@/lib/db';
+
+describe('Cache Metrics', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    clearRoleHierarchyCache();
+    resetCacheMetrics();
+  });
+
+  describe('getCacheMetrics', () => {
+    it('should return initial metrics with zero values', () => {
+      const metrics = getCacheMetrics();
+
+      expect(metrics.hits).toBe(0);
+      expect(metrics.misses).toBe(0);
+      expect(metrics.size).toBe(0);
+      expect(metrics.hitRate).toBe(0);
+      expect(metrics.lastWarmTimeMs).toBeNull();
+      expect(metrics.lastWarmAt).toBeNull();
+    });
+
+    it('should track cache miss on first access', async () => {
+      vi.mocked(prisma.role.findMany).mockResolvedValue([
+        { id: 'role-1', name: 'ROLE_USER', parentId: null },
+      ]);
+
+      const user = {
+        id: 'user-1',
+        userRoles: [
+          {
+            organizationId: null,
+            role: { id: 'role-1', name: 'ROLE_USER', parentId: null },
+          },
+        ],
+      };
+
+      await hasRole(user, 'ROLE_USER', null);
+
+      const metrics = getCacheMetrics();
+      expect(metrics.misses).toBe(1);
+      expect(metrics.hits).toBe(0);
+      expect(metrics.hitRate).toBe(0);
+    });
+
+    it('should track cache hit on subsequent access', async () => {
+      vi.mocked(prisma.role.findMany).mockResolvedValue([
+        { id: 'role-1', name: 'ROLE_USER', parentId: null },
+      ]);
+
+      const user = {
+        id: 'user-1',
+        userRoles: [
+          {
+            organizationId: null,
+            role: { id: 'role-1', name: 'ROLE_USER', parentId: null },
+          },
+        ],
+      };
+
+      // First call - cache miss
+      await hasRole(user, 'ROLE_USER', null);
+      // Second call - cache hit
+      await hasRole(user, 'ROLE_USER', null);
+
+      const metrics = getCacheMetrics();
+      expect(metrics.misses).toBe(1);
+      expect(metrics.hits).toBe(1);
+      expect(metrics.hitRate).toBe(0.5);
+    });
+
+    it('should track cache size after warming', async () => {
+      vi.mocked(prisma.role.findMany).mockResolvedValue([
+        { id: 'role-1', name: 'ROLE_USER', parentId: null },
+        { id: 'role-2', name: 'ROLE_MODERATOR', parentId: 'role-1' },
+        { id: 'role-3', name: 'ROLE_ADMIN', parentId: 'role-2' },
+      ]);
+
+      const user = {
+        id: 'user-1',
+        userRoles: [
+          {
+            organizationId: null,
+            role: { id: 'role-1', name: 'ROLE_USER', parentId: null },
+          },
+        ],
+      };
+
+      await hasRole(user, 'ROLE_USER', null);
+
+      const metrics = getCacheMetrics();
+      expect(metrics.size).toBe(3);
+    });
+
+    it('should track warm time after cache build', async () => {
+      vi.mocked(prisma.role.findMany).mockResolvedValue([
+        { id: 'role-1', name: 'ROLE_USER', parentId: null },
+      ]);
+
+      const user = {
+        id: 'user-1',
+        userRoles: [
+          {
+            organizationId: null,
+            role: { id: 'role-1', name: 'ROLE_USER', parentId: null },
+          },
+        ],
+      };
+
+      await hasRole(user, 'ROLE_USER', null);
+
+      const metrics = getCacheMetrics();
+      expect(metrics.lastWarmTimeMs).toBeGreaterThanOrEqual(0);
+      expect(metrics.lastWarmAt).toBeInstanceOf(Date);
+    });
+
+    it('should calculate hit rate correctly', async () => {
+      vi.mocked(prisma.role.findMany).mockResolvedValue([
+        { id: 'role-1', name: 'ROLE_USER', parentId: null },
+      ]);
+
+      const user = {
+        id: 'user-1',
+        userRoles: [
+          {
+            organizationId: null,
+            role: { id: 'role-1', name: 'ROLE_USER', parentId: null },
+          },
+        ],
+      };
+
+      // 1 miss, then 4 hits
+      await hasRole(user, 'ROLE_USER', null);
+      await hasRole(user, 'ROLE_USER', null);
+      await hasRole(user, 'ROLE_USER', null);
+      await hasRole(user, 'ROLE_USER', null);
+      await hasRole(user, 'ROLE_USER', null);
+
+      const metrics = getCacheMetrics();
+      expect(metrics.misses).toBe(1);
+      expect(metrics.hits).toBe(4);
+      expect(metrics.hitRate).toBe(0.8);
+    });
+  });
+
+  describe('resetCacheMetrics', () => {
+    it('should reset hit and miss counters', async () => {
+      vi.mocked(prisma.role.findMany).mockResolvedValue([
+        { id: 'role-1', name: 'ROLE_USER', parentId: null },
+      ]);
+
+      const user = {
+        id: 'user-1',
+        userRoles: [
+          {
+            organizationId: null,
+            role: { id: 'role-1', name: 'ROLE_USER', parentId: null },
+          },
+        ],
+      };
+
+      await hasRole(user, 'ROLE_USER', null);
+      await hasRole(user, 'ROLE_USER', null);
+
+      // Verify counts before reset
+      let metrics = getCacheMetrics();
+      expect(metrics.misses).toBe(1);
+      expect(metrics.hits).toBe(1);
+
+      // Reset counters
+      resetCacheMetrics();
+
+      // Verify counters are reset but cache state preserved
+      metrics = getCacheMetrics();
+      expect(metrics.hits).toBe(0);
+      expect(metrics.misses).toBe(0);
+      expect(metrics.size).toBe(1); // Size preserved
+      expect(metrics.lastWarmTimeMs).not.toBeNull(); // Warm time preserved
+    });
+  });
+
+  describe('clearRoleHierarchyCache', () => {
+    it('should reset cache size to zero', async () => {
+      vi.mocked(prisma.role.findMany).mockResolvedValue([
+        { id: 'role-1', name: 'ROLE_USER', parentId: null },
+        { id: 'role-2', name: 'ROLE_MODERATOR', parentId: 'role-1' },
+      ]);
+
+      const user = {
+        id: 'user-1',
+        userRoles: [
+          {
+            organizationId: null,
+            role: { id: 'role-1', name: 'ROLE_USER', parentId: null },
+          },
+        ],
+      };
+
+      await hasRole(user, 'ROLE_USER', null);
+
+      let metrics = getCacheMetrics();
+      expect(metrics.size).toBe(2);
+
+      clearRoleHierarchyCache();
+
+      metrics = getCacheMetrics();
+      expect(metrics.size).toBe(0);
+    });
+
+    it('should cause cache miss on next access after clear', async () => {
+      vi.mocked(prisma.role.findMany).mockResolvedValue([
+        { id: 'role-1', name: 'ROLE_USER', parentId: null },
+      ]);
+
+      const user = {
+        id: 'user-1',
+        userRoles: [
+          {
+            organizationId: null,
+            role: { id: 'role-1', name: 'ROLE_USER', parentId: null },
+          },
+        ],
+      };
+
+      // First access - miss
+      await hasRole(user, 'ROLE_USER', null);
+      // Second access - hit
+      await hasRole(user, 'ROLE_USER', null);
+
+      let metrics = getCacheMetrics();
+      expect(metrics.misses).toBe(1);
+      expect(metrics.hits).toBe(1);
+
+      // Clear cache
+      clearRoleHierarchyCache();
+      resetCacheMetrics();
+
+      // Third access - miss again
+      await hasRole(user, 'ROLE_USER', null);
+
+      metrics = getCacheMetrics();
+      expect(metrics.misses).toBe(1);
+      expect(metrics.hits).toBe(0);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Add `CacheMetrics` interface with hits, misses, size, lastWarmTimeMs, lastWarmAt
- Track cache hits/misses in `getRoleHierarchy()` 
- Add `getCacheMetrics()` to retrieve metrics with computed `hitRate`
- Add `resetCacheMetrics()` for periodic monitoring resets

## Test plan
- [x] Unit tests for all cache metrics functionality (9 new tests)
- [x] All 637 unit tests pass
- [x] Build passes

Closes #240

🤖 Generated with [Claude Code](https://claude.com/claude-code)