### PR TITLE
feat(theming): add instance-level branding and layout configuration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -70,3 +70,32 @@ NEXT_PUBLIC_APP_URL=http://localhost:3000
 # =============================================================================
 
 TEST_DATABASE_URL=postgresql://soclestack:soclestack123@localhost:5432/soclestack_test
+
+# =============================================================================
+# OPTIONAL - Branding
+# =============================================================================
+
+# App name shown in title, emails, footer
+# BRAND_NAME=SocleStack
+
+# Logo URL (relative to public/ or absolute URL)
+# BRAND_LOGO_URL=/logo.svg
+
+# Favicon URL
+# BRAND_FAVICON_URL=/favicon.ico
+
+# Primary brand color (hex)
+# BRAND_PRIMARY_COLOR=#3b82f6
+
+# =============================================================================
+# OPTIONAL - Layout
+# =============================================================================
+
+# Auth page layout: centered | split | fullpage
+# LAYOUT_AUTH_STYLE=centered
+
+# Navigation style: top | sidebar
+# LAYOUT_NAV_STYLE=top
+
+# UI density: compact | comfortable
+# LAYOUT_DENSITY=comfortable

--- a/public/logo.svg
+++ b/public/logo.svg
@@ -1,0 +1,10 @@
+<svg width="512" height="512" viewBox="0 0 512 512" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <!-- Bottom pill - darkest blue -->
+  <rect x="128" y="360" width="256" height="72" rx="36" fill="#1e3a8a"/>
+  <!-- Middle pill - medium blue -->
+  <rect x="152" y="272" width="208" height="72" rx="36" fill="#2563eb"/>
+  <!-- Upper pill - light blue -->
+  <rect x="176" y="184" width="160" height="72" rx="36" fill="#60a5fa"/>
+  <!-- Top circle - lightest blue -->
+  <circle cx="256" cy="120" r="48" fill="#93c5fd"/>
+</svg>

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -16,17 +16,6 @@
   --font-mono: var(--font-geist-mono);
 }
 
-/* Density modes */
-[data-density='compact'] {
-  --spacing-base: 0.75rem;
-  --text-size-base: 0.875rem;
-}
-
-[data-density='comfortable'] {
-  --spacing-base: 1rem;
-  --text-size-base: 1rem;
-}
-
 @media (prefers-color-scheme: dark) {
   :root {
     --background: #0a0a0a;

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -3,13 +3,28 @@
 :root {
   --background: #ffffff;
   --foreground: #171717;
+  /* Brand colors injected via layout.tsx style attribute */
 }
 
 @theme inline {
   --color-background: var(--background);
   --color-foreground: var(--foreground);
+  --color-brand-primary: var(--brand-primary, #3b82f6);
+  --color-brand-primary-hover: var(--brand-primary-hover, #2563eb);
+  --color-brand-primary-light: var(--brand-primary-light, #dbeafe);
   --font-sans: var(--font-geist-sans);
   --font-mono: var(--font-geist-mono);
+}
+
+/* Density modes */
+[data-density='compact'] {
+  --spacing-base: 0.75rem;
+  --text-size-base: 0.875rem;
+}
+
+[data-density='comfortable'] {
+  --spacing-base: 1rem;
+  --text-size-base: 1rem;
 }
 
 @media (prefers-color-scheme: dark) {

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -3,7 +3,7 @@ import { Geist, Geist_Mono } from 'next/font/google';
 import './globals.css';
 import { ImpersonationBannerWrapper } from '@/components/admin/impersonation-banner-wrapper';
 import { SessionTimeoutWarning } from '@/components/session/session-timeout-warning';
-import { getBranding, getLayout } from '@/lib/branding';
+import { getBranding } from '@/lib/branding';
 import { darken, lighten } from '@/lib/color-utils';
 
 const geistSans = Geist({
@@ -33,7 +33,6 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   const branding = getBranding();
-  const layout = getLayout();
 
   const brandStyles = {
     '--brand-primary': branding.primaryColor,
@@ -45,7 +44,6 @@ export default function RootLayout({
     <html lang="en" style={brandStyles}>
       <body
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
-        data-density={layout.density}
       >
         <ImpersonationBannerWrapper />
         {children}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -3,6 +3,8 @@ import { Geist, Geist_Mono } from 'next/font/google';
 import './globals.css';
 import { ImpersonationBannerWrapper } from '@/components/admin/impersonation-banner-wrapper';
 import { SessionTimeoutWarning } from '@/components/session/session-timeout-warning';
+import { getBranding, getLayout } from '@/lib/branding';
+import { darken, lighten } from '@/lib/color-utils';
 
 const geistSans = Geist({
   variable: '--font-geist-sans',
@@ -14,21 +16,36 @@ const geistMono = Geist_Mono({
   subsets: ['latin'],
 });
 
-export const metadata: Metadata = {
-  title: 'SocleStack - Next.js User Management',
-  description:
-    'A complete Next.js application with Enterprise-grade user management features',
-};
+export async function generateMetadata(): Promise<Metadata> {
+  const branding = getBranding();
+  return {
+    title: `${branding.name} - User Management`,
+    description: `${branding.name} - Enterprise-grade user management`,
+    icons: {
+      icon: branding.faviconUrl,
+    },
+  };
+}
 
 export default function RootLayout({
   children,
 }: Readonly<{
   children: React.ReactNode;
 }>) {
+  const branding = getBranding();
+  const layout = getLayout();
+
+  const brandStyles = {
+    '--brand-primary': branding.primaryColor,
+    '--brand-primary-hover': darken(branding.primaryColor, 10),
+    '--brand-primary-light': lighten(branding.primaryColor, 40),
+  } as React.CSSProperties;
+
   return (
-    <html lang="en">
+    <html lang="en" style={brandStyles}>
       <body
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
+        data-density={layout.density}
       >
         <ImpersonationBannerWrapper />
         {children}

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -1,44 +1,39 @@
 import { Suspense } from 'react';
 import { LoginForm } from '@/components/auth/login-form';
+import { AuthLayout } from '@/components/layouts/auth-layout';
 import {
   Card,
   CardDescription,
   CardHeader,
   CardTitle,
 } from '@/components/ui/card';
+import { getBranding } from '@/lib/branding';
 
 export default function LoginPage() {
   return (
-    <div className="flex min-h-screen items-center justify-center bg-gray-50 px-4 py-12 sm:px-6 lg:px-8">
-      <div className="w-full max-w-md space-y-8">
-        <div>
-          <h2 className="mt-6 text-center text-3xl font-extrabold text-gray-900">
-            Welcome back
-          </h2>
-          <p className="mt-2 text-center text-sm text-gray-600">
-            Sign in to your account to continue
-          </p>
-        </div>
-        <Suspense
-          fallback={
-            <Card className="mx-auto w-full max-w-md">
-              <CardHeader>
-                <CardTitle>Loading...</CardTitle>
-                <CardDescription>
-                  Please wait while we load the login form.
-                </CardDescription>
-              </CardHeader>
-            </Card>
-          }
-        >
-          <LoginForm />
-        </Suspense>
-      </div>
-    </div>
+    <AuthLayout title="Welcome back" description="Sign in to your account to continue">
+      <Suspense
+        fallback={
+          <Card className="mx-auto w-full max-w-md">
+            <CardHeader>
+              <CardTitle>Loading...</CardTitle>
+              <CardDescription>
+                Please wait while we load the login form.
+              </CardDescription>
+            </CardHeader>
+          </Card>
+        }
+      >
+        <LoginForm />
+      </Suspense>
+    </AuthLayout>
   );
 }
 
-export const metadata = {
-  title: 'Sign In - SocleStack',
-  description: 'Sign in to your SocleStack account',
-};
+export async function generateMetadata() {
+  const branding = getBranding();
+  return {
+    title: `Sign In - ${branding.name}`,
+    description: `Sign in to your ${branding.name} account`,
+  };
+}

--- a/src/app/register/page.tsx
+++ b/src/app/register/page.tsx
@@ -1,44 +1,44 @@
 import { Suspense } from 'react';
 import { RegisterForm } from '@/components/auth/register-form';
+import { AuthLayout } from '@/components/layouts/auth-layout';
 import {
   Card,
   CardDescription,
   CardHeader,
   CardTitle,
 } from '@/components/ui/card';
+import { getBranding } from '@/lib/branding';
 
 export default function RegisterPage() {
+  const branding = getBranding();
+
   return (
-    <div className="flex min-h-screen items-center justify-center bg-gray-50 px-4 py-12 sm:px-6 lg:px-8">
-      <div className="w-full max-w-md space-y-8">
-        <div>
-          <h2 className="mt-6 text-center text-3xl font-extrabold text-gray-900">
-            Create your account
-          </h2>
-          <p className="mt-2 text-center text-sm text-gray-600">
-            Join SocleStack to get started
-          </p>
-        </div>
-        <Suspense
-          fallback={
-            <Card className="mx-auto w-full max-w-md">
-              <CardHeader>
-                <CardTitle>Loading...</CardTitle>
-                <CardDescription>
-                  Please wait while we load the registration form.
-                </CardDescription>
-              </CardHeader>
-            </Card>
-          }
-        >
-          <RegisterForm />
-        </Suspense>
-      </div>
-    </div>
+    <AuthLayout
+      title="Create your account"
+      description={`Join ${branding.name} to get started`}
+    >
+      <Suspense
+        fallback={
+          <Card className="mx-auto w-full max-w-md">
+            <CardHeader>
+              <CardTitle>Loading...</CardTitle>
+              <CardDescription>
+                Please wait while we load the registration form.
+              </CardDescription>
+            </CardHeader>
+          </Card>
+        }
+      >
+        <RegisterForm />
+      </Suspense>
+    </AuthLayout>
   );
 }
 
-export const metadata = {
-  title: 'Sign Up - SocleStack',
-  description: 'Create a new SocleStack account',
-};
+export async function generateMetadata() {
+  const branding = getBranding();
+  return {
+    title: `Sign Up - ${branding.name}`,
+    description: `Create a new ${branding.name} account`,
+  };
+}

--- a/src/components/layouts/app-layout.tsx
+++ b/src/components/layouts/app-layout.tsx
@@ -1,0 +1,17 @@
+import { getLayout } from '@/lib/branding';
+import { NavTop } from './nav-top';
+import { NavSidebar } from './nav-sidebar';
+
+interface AppLayoutProps {
+  children: React.ReactNode;
+}
+
+export function AppLayout({ children }: AppLayoutProps) {
+  const { navStyle } = getLayout();
+
+  if (navStyle === 'sidebar') {
+    return <NavSidebar>{children}</NavSidebar>;
+  }
+
+  return <NavTop>{children}</NavTop>;
+}

--- a/src/components/layouts/auth-centered.tsx
+++ b/src/components/layouts/auth-centered.tsx
@@ -1,0 +1,38 @@
+import { getBranding } from '@/lib/branding';
+
+interface AuthCenteredProps {
+  children: React.ReactNode;
+  title?: string;
+  description?: string;
+}
+
+export function AuthCentered({
+  children,
+  title,
+  description,
+}: AuthCenteredProps) {
+  const branding = getBranding();
+
+  return (
+    <div className="flex min-h-screen items-center justify-center bg-gray-50 px-4 py-12 sm:px-6 lg:px-8">
+      <div className="w-full max-w-md space-y-8">
+        <div className="text-center">
+          <img
+            src={branding.logoUrl}
+            alt={branding.name}
+            className="mx-auto h-12 w-auto"
+          />
+          {title && (
+            <h1 className="mt-6 text-3xl font-extrabold text-gray-900">
+              {title}
+            </h1>
+          )}
+          {description && (
+            <p className="mt-2 text-sm text-gray-600">{description}</p>
+          )}
+        </div>
+        {children}
+      </div>
+    </div>
+  );
+}

--- a/src/components/layouts/auth-centered.tsx
+++ b/src/components/layouts/auth-centered.tsx
@@ -1,3 +1,4 @@
+import Image from 'next/image';
 import { getBranding } from '@/lib/branding';
 
 interface AuthCenteredProps {
@@ -17,10 +18,13 @@ export function AuthCentered({
     <div className="flex min-h-screen items-center justify-center bg-gray-50 px-4 py-12 sm:px-6 lg:px-8">
       <div className="w-full max-w-md space-y-8">
         <div className="text-center">
-          <img
+          <Image
             src={branding.logoUrl}
             alt={branding.name}
-            className="mx-auto h-12 w-auto"
+            width={48}
+            height={48}
+            className="mx-auto"
+            unoptimized
           />
           {title && (
             <h1 className="mt-6 text-3xl font-extrabold text-gray-900">

--- a/src/components/layouts/auth-fullpage.tsx
+++ b/src/components/layouts/auth-fullpage.tsx
@@ -1,3 +1,4 @@
+import Image from 'next/image';
 import { getBranding } from '@/lib/branding';
 
 interface AuthFullpageProps {
@@ -16,10 +17,12 @@ export function AuthFullpage({
   return (
     <div className="flex min-h-screen flex-col">
       <header className="border-b bg-white px-4 py-4">
-        <img
+        <Image
           src={branding.logoUrl}
           alt={branding.name}
-          className="h-8 w-auto"
+          width={32}
+          height={32}
+          unoptimized
         />
       </header>
       <main className="flex flex-1 items-center justify-center bg-gray-50 p-4">

--- a/src/components/layouts/auth-fullpage.tsx
+++ b/src/components/layouts/auth-fullpage.tsx
@@ -1,0 +1,42 @@
+import { getBranding } from '@/lib/branding';
+
+interface AuthFullpageProps {
+  children: React.ReactNode;
+  title?: string;
+  description?: string;
+}
+
+export function AuthFullpage({
+  children,
+  title,
+  description,
+}: AuthFullpageProps) {
+  const branding = getBranding();
+
+  return (
+    <div className="flex min-h-screen flex-col">
+      <header className="border-b bg-white px-4 py-4">
+        <img
+          src={branding.logoUrl}
+          alt={branding.name}
+          className="h-8 w-auto"
+        />
+      </header>
+      <main className="flex flex-1 items-center justify-center bg-gray-50 p-4">
+        <div className="w-full max-w-lg">
+          {(title || description) && (
+            <div className="mb-8 text-center">
+              {title && (
+                <h1 className="text-3xl font-bold text-gray-900">{title}</h1>
+              )}
+              {description && (
+                <p className="mt-2 text-gray-600">{description}</p>
+              )}
+            </div>
+          )}
+          {children}
+        </div>
+      </main>
+    </div>
+  );
+}

--- a/src/components/layouts/auth-layout.tsx
+++ b/src/components/layouts/auth-layout.tsx
@@ -1,0 +1,35 @@
+import { getLayout } from '@/lib/branding';
+import { AuthCentered } from './auth-centered';
+import { AuthSplit } from './auth-split';
+import { AuthFullpage } from './auth-fullpage';
+
+interface AuthLayoutProps {
+  children: React.ReactNode;
+  title?: string;
+  description?: string;
+}
+
+export function AuthLayout({ children, title, description }: AuthLayoutProps) {
+  const { authStyle } = getLayout();
+
+  switch (authStyle) {
+    case 'split':
+      return (
+        <AuthSplit title={title} description={description}>
+          {children}
+        </AuthSplit>
+      );
+    case 'fullpage':
+      return (
+        <AuthFullpage title={title} description={description}>
+          {children}
+        </AuthFullpage>
+      );
+    default:
+      return (
+        <AuthCentered title={title} description={description}>
+          {children}
+        </AuthCentered>
+      );
+  }
+}

--- a/src/components/layouts/auth-split.tsx
+++ b/src/components/layouts/auth-split.tsx
@@ -1,0 +1,52 @@
+import { getBranding } from '@/lib/branding';
+
+interface AuthSplitProps {
+  children: React.ReactNode;
+  title?: string;
+  description?: string;
+}
+
+export function AuthSplit({ children, title, description }: AuthSplitProps) {
+  const branding = getBranding();
+
+  return (
+    <div className="flex min-h-screen">
+      {/* Left: Form */}
+      <div className="flex flex-1 flex-col justify-center px-4 py-12 sm:px-6 lg:flex-none lg:px-20 xl:px-24">
+        <div className="mx-auto w-full max-w-sm lg:w-96">
+          <div>
+            <img
+              src={branding.logoUrl}
+              alt={branding.name}
+              className="h-10 w-auto"
+            />
+            {title && (
+              <h1 className="mt-6 text-2xl font-bold text-gray-900">{title}</h1>
+            )}
+            {description && (
+              <p className="mt-2 text-sm text-gray-600">{description}</p>
+            )}
+          </div>
+          <div className="mt-8">{children}</div>
+        </div>
+      </div>
+
+      {/* Right: Hero */}
+      <div
+        className="relative hidden w-0 flex-1 lg:block"
+        style={{ backgroundColor: 'var(--brand-primary-light)' }}
+      >
+        <div className="flex h-full items-center justify-center p-12">
+          <div className="text-center">
+            <h2 className="text-3xl font-bold text-gray-800">
+              Welcome to {branding.name}
+            </h2>
+            <p className="mt-4 text-lg text-gray-600">
+              Secure authentication for your application
+            </p>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/layouts/auth-split.tsx
+++ b/src/components/layouts/auth-split.tsx
@@ -1,3 +1,4 @@
+import Image from 'next/image';
 import { getBranding } from '@/lib/branding';
 
 interface AuthSplitProps {
@@ -15,10 +16,12 @@ export function AuthSplit({ children, title, description }: AuthSplitProps) {
       <div className="flex flex-1 flex-col justify-center px-4 py-12 sm:px-6 lg:flex-none lg:px-20 xl:px-24">
         <div className="mx-auto w-full max-w-sm lg:w-96">
           <div>
-            <img
+            <Image
               src={branding.logoUrl}
               alt={branding.name}
-              className="h-10 w-auto"
+              width={40}
+              height={40}
+              unoptimized
             />
             {title && (
               <h1 className="mt-6 text-2xl font-bold text-gray-900">{title}</h1>

--- a/src/components/layouts/authenticated-layout.tsx
+++ b/src/components/layouts/authenticated-layout.tsx
@@ -1,14 +1,9 @@
-import { Navbar } from '@/components/navigation/navbar';
+import { AppLayout } from './app-layout';
 
 interface AuthenticatedLayoutProps {
   children: React.ReactNode;
 }
 
 export function AuthenticatedLayout({ children }: AuthenticatedLayoutProps) {
-  return (
-    <div className="min-h-screen bg-gray-50">
-      <Navbar />
-      {children}
-    </div>
-  );
+  return <AppLayout>{children}</AppLayout>;
 }

--- a/src/components/layouts/nav-sidebar.tsx
+++ b/src/components/layouts/nav-sidebar.tsx
@@ -1,0 +1,208 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import Link from 'next/link';
+import { useRouter, usePathname } from 'next/navigation';
+import { getBranding } from '@/lib/branding';
+import { apiPost } from '@/lib/api-client';
+import { hasMinimumRole, displayRole, ROLES } from '@/lib/security/client';
+import {
+  Home,
+  User,
+  Settings,
+  LogOut,
+  Users,
+  Building2,
+  ChevronLeft,
+  ChevronRight,
+} from 'lucide-react';
+
+interface UserData {
+  id: string;
+  email: string;
+  username?: string;
+  firstName?: string;
+  lastName: string;
+  role: string;
+  organizationId?: string;
+  organizationRole?: 'OWNER' | 'ADMIN' | 'MEMBER';
+}
+
+interface NavSidebarProps {
+  children: React.ReactNode;
+}
+
+export function NavSidebar({ children }: NavSidebarProps) {
+  const router = useRouter();
+  const pathname = usePathname();
+  const branding = getBranding();
+  const [collapsed, setCollapsed] = useState(false);
+  const [user, setUser] = useState<UserData | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+
+  useEffect(() => {
+    fetchCurrentUser();
+  }, []);
+
+  const fetchCurrentUser = async () => {
+    try {
+      const response = await fetch('/api/auth/me');
+      if (response.ok) {
+        const data = await response.json();
+        setUser(data.user);
+      }
+    } catch (error) {
+      console.error('Failed to fetch user:', error);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const handleLogout = async () => {
+    try {
+      await apiPost('/api/auth/logout');
+      localStorage.removeItem('accessToken');
+      localStorage.removeItem('refreshToken');
+      router.push('/login');
+      router.refresh();
+    } catch (error) {
+      console.error('Logout failed:', error);
+    }
+  };
+
+  const getDisplayName = () => {
+    if (user?.firstName && user?.lastName) {
+      return `${user.firstName} ${user.lastName}`;
+    }
+    if (user?.username) {
+      return user.username;
+    }
+    return user?.email || 'User';
+  };
+
+  const navItems = [
+    { href: '/dashboard', label: 'Dashboard', icon: Home },
+    { href: '/profile', label: 'Profile', icon: User },
+  ];
+
+  if (user?.organizationId) {
+    navItems.push({
+      href: '/organization',
+      label: 'Organization',
+      icon: Building2,
+    });
+  }
+
+  if (user && hasMinimumRole(user.role, ROLES.MODERATOR)) {
+    navItems.push({ href: '/admin', label: 'Admin', icon: Users });
+  }
+
+  const isActive = (href: string) => pathname.startsWith(href);
+
+  return (
+    <div className="flex min-h-screen">
+      {/* Sidebar */}
+      <aside
+        className={`flex flex-col bg-gray-900 text-white transition-all duration-300 ${
+          collapsed ? 'w-16' : 'w-64'
+        }`}
+      >
+        {/* Header */}
+        <div className="flex h-16 items-center justify-between border-b border-gray-800 px-4">
+          {!collapsed && (
+            <Link href="/dashboard" className="flex items-center space-x-2">
+              <img
+                src={branding.logoUrl}
+                alt={branding.name}
+                className="h-8 w-8"
+              />
+              <span className="font-semibold">{branding.name}</span>
+            </Link>
+          )}
+          {collapsed && (
+            <Link href="/dashboard" className="mx-auto">
+              <img
+                src={branding.logoUrl}
+                alt={branding.name}
+                className="h-8 w-8"
+              />
+            </Link>
+          )}
+        </div>
+
+        {/* Navigation */}
+        <nav className="flex-1 space-y-1 px-2 py-4">
+          {navItems.map((item) => {
+            const Icon = item.icon;
+            const active = isActive(item.href);
+            return (
+              <Link
+                key={item.href}
+                href={item.href}
+                className={`flex items-center rounded-md px-3 py-2 text-sm font-medium transition-colors ${
+                  active
+                    ? 'bg-gray-800 text-white'
+                    : 'text-gray-300 hover:bg-gray-800 hover:text-white'
+                } ${collapsed ? 'justify-center' : 'space-x-3'}`}
+                title={collapsed ? item.label : undefined}
+              >
+                <Icon size={20} />
+                {!collapsed && <span>{item.label}</span>}
+              </Link>
+            );
+          })}
+        </nav>
+
+        {/* User section */}
+        {!isLoading && user && (
+          <div className="border-t border-gray-800 p-4">
+            {!collapsed && (
+              <div className="mb-3">
+                <p className="truncate text-sm font-medium text-white">
+                  {getDisplayName()}
+                </p>
+                <p className="truncate text-xs text-gray-400">{user.email}</p>
+                {hasMinimumRole(user.role, ROLES.MODERATOR) && (
+                  <span className="mt-1 inline-flex items-center rounded-full bg-gray-800 px-2 py-0.5 text-xs font-medium text-gray-300">
+                    {displayRole(user.role)}
+                  </span>
+                )}
+              </div>
+            )}
+            <div
+              className={`flex ${collapsed ? 'flex-col space-y-2' : 'space-x-2'}`}
+            >
+              <Link
+                href="/profile"
+                className="flex items-center justify-center rounded-md p-2 text-gray-300 hover:bg-gray-800 hover:text-white"
+                title="Settings"
+              >
+                <Settings size={18} />
+              </Link>
+              <button
+                type="button"
+                onClick={handleLogout}
+                className="flex items-center justify-center rounded-md p-2 text-gray-300 hover:bg-gray-800 hover:text-white"
+                title="Logout"
+              >
+                <LogOut size={18} />
+              </button>
+            </div>
+          </div>
+        )}
+
+        {/* Collapse toggle */}
+        <button
+          type="button"
+          onClick={() => setCollapsed(!collapsed)}
+          className="flex items-center justify-center border-t border-gray-800 p-4 text-gray-400 hover:text-white"
+        >
+          {collapsed ? <ChevronRight size={20} /> : <ChevronLeft size={20} />}
+        </button>
+      </aside>
+
+      {/* Main content */}
+      <main className="flex-1 bg-gray-50">{children}</main>
+    </div>
+  );
+}

--- a/src/components/layouts/nav-sidebar.tsx
+++ b/src/components/layouts/nav-sidebar.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useState, useEffect } from 'react';
+import Image from 'next/image';
 import Link from 'next/link';
 import { useRouter, usePathname } from 'next/navigation';
 import { getBranding } from '@/lib/branding';
@@ -111,20 +112,24 @@ export function NavSidebar({ children }: NavSidebarProps) {
         <div className="flex h-16 items-center justify-between border-b border-gray-800 px-4">
           {!collapsed && (
             <Link href="/dashboard" className="flex items-center space-x-2">
-              <img
+              <Image
                 src={branding.logoUrl}
                 alt={branding.name}
-                className="h-8 w-8"
+                width={32}
+                height={32}
+                unoptimized
               />
               <span className="font-semibold">{branding.name}</span>
             </Link>
           )}
           {collapsed && (
             <Link href="/dashboard" className="mx-auto">
-              <img
+              <Image
                 src={branding.logoUrl}
                 alt={branding.name}
-                className="h-8 w-8"
+                width={32}
+                height={32}
+                unoptimized
               />
             </Link>
           )}

--- a/src/components/layouts/nav-top.tsx
+++ b/src/components/layouts/nav-top.tsx
@@ -1,0 +1,14 @@
+import { Navbar } from '@/components/navigation/navbar';
+
+interface NavTopProps {
+  children: React.ReactNode;
+}
+
+export function NavTop({ children }: NavTopProps) {
+  return (
+    <div className="min-h-screen bg-gray-50">
+      <Navbar />
+      <main>{children}</main>
+    </div>
+  );
+}

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -12,11 +12,12 @@ const Button = forwardRef<HTMLButtonElement, ButtonProps>(
       <button
         className={clsx(
           'inline-flex items-center justify-center rounded-md font-medium transition-colors',
-          'focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2 focus-visible:outline-none',
+          'focus-visible:ring-2 focus-visible:ring-brand-primary focus-visible:ring-offset-2 focus-visible:outline-none',
           'disabled:cursor-not-allowed disabled:opacity-50',
           {
             // Variants
-            'bg-blue-600 text-white hover:bg-blue-700': variant === 'primary',
+            'bg-brand-primary text-white hover:bg-brand-primary-hover':
+              variant === 'primary',
             'bg-gray-200 text-gray-900 hover:bg-gray-300':
               variant === 'secondary',
             'bg-red-600 text-white hover:bg-red-700': variant === 'destructive',

--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -12,7 +12,7 @@ const Input = forwardRef<HTMLInputElement, InputProps>(
         className={clsx(
           'flex h-10 w-full rounded-md border border-gray-200 bg-white px-3 py-2 text-sm',
           'placeholder:text-gray-500',
-          'focus:border-transparent focus:ring-2 focus:ring-blue-500 focus:outline-none',
+          'focus:border-transparent focus:ring-2 focus:ring-brand-primary focus:outline-none',
           'disabled:cursor-not-allowed disabled:opacity-50',
           {
             'border-red-500 focus:ring-red-500': error,

--- a/src/lib/branding.ts
+++ b/src/lib/branding.ts
@@ -1,0 +1,50 @@
+/**
+ * Branding Configuration
+ *
+ * Reads instance-level branding from environment variables.
+ * Future: Will support org-level branding from database.
+ */
+
+export interface BrandingConfig {
+  name: string;
+  logoUrl: string;
+  faviconUrl: string;
+  primaryColor: string;
+}
+
+export interface LayoutConfig {
+  authStyle: 'centered' | 'split' | 'fullpage';
+  navStyle: 'top' | 'sidebar';
+  density: 'compact' | 'comfortable';
+}
+
+/**
+ * Get branding configuration
+ *
+ * @param orgId - Future: org ID for org-specific branding
+ * @returns Branding config (currently instance-level only)
+ */
+export function getBranding(_orgId?: string): BrandingConfig {
+  // Future: Check DB for org-specific branding first
+  return {
+    name: process.env.BRAND_NAME ?? 'SocleStack',
+    logoUrl: process.env.BRAND_LOGO_URL ?? '/logo.svg',
+    faviconUrl: process.env.BRAND_FAVICON_URL ?? '/favicon.ico',
+    primaryColor: process.env.BRAND_PRIMARY_COLOR ?? '#3b82f6',
+  };
+}
+
+/**
+ * Get layout configuration
+ */
+export function getLayout(): LayoutConfig {
+  return {
+    authStyle:
+      (process.env.LAYOUT_AUTH_STYLE as LayoutConfig['authStyle']) ??
+      'centered',
+    navStyle:
+      (process.env.LAYOUT_NAV_STYLE as LayoutConfig['navStyle']) ?? 'top',
+    density:
+      (process.env.LAYOUT_DENSITY as LayoutConfig['density']) ?? 'comfortable',
+  };
+}

--- a/src/lib/branding.ts
+++ b/src/lib/branding.ts
@@ -18,6 +18,52 @@ export interface LayoutConfig {
   density: 'compact' | 'comfortable';
 }
 
+const VALID_AUTH_STYLES = ['centered', 'split', 'fullpage'] as const;
+const VALID_NAV_STYLES = ['top', 'sidebar'] as const;
+const VALID_DENSITIES = ['compact', 'comfortable'] as const;
+
+function validateAuthStyle(
+  value: string | undefined
+): LayoutConfig['authStyle'] {
+  if (value && VALID_AUTH_STYLES.includes(value as LayoutConfig['authStyle'])) {
+    return value as LayoutConfig['authStyle'];
+  }
+  if (value) {
+    console.warn(
+      `Invalid LAYOUT_AUTH_STYLE "${value}". Valid options: ${VALID_AUTH_STYLES.join(', ')}. Using default "centered".`
+    );
+  }
+  return 'centered';
+}
+
+function validateNavStyle(
+  value: string | undefined
+): LayoutConfig['navStyle'] {
+  if (value && VALID_NAV_STYLES.includes(value as LayoutConfig['navStyle'])) {
+    return value as LayoutConfig['navStyle'];
+  }
+  if (value) {
+    console.warn(
+      `Invalid LAYOUT_NAV_STYLE "${value}". Valid options: ${VALID_NAV_STYLES.join(', ')}. Using default "top".`
+    );
+  }
+  return 'top';
+}
+
+function validateDensity(
+  value: string | undefined
+): LayoutConfig['density'] {
+  if (value && VALID_DENSITIES.includes(value as LayoutConfig['density'])) {
+    return value as LayoutConfig['density'];
+  }
+  if (value) {
+    console.warn(
+      `Invalid LAYOUT_DENSITY "${value}". Valid options: ${VALID_DENSITIES.join(', ')}. Using default "comfortable".`
+    );
+  }
+  return 'comfortable';
+}
+
 /**
  * Get branding configuration
  *
@@ -39,12 +85,8 @@ export function getBranding(_orgId?: string): BrandingConfig {
  */
 export function getLayout(): LayoutConfig {
   return {
-    authStyle:
-      (process.env.LAYOUT_AUTH_STYLE as LayoutConfig['authStyle']) ??
-      'centered',
-    navStyle:
-      (process.env.LAYOUT_NAV_STYLE as LayoutConfig['navStyle']) ?? 'top',
-    density:
-      (process.env.LAYOUT_DENSITY as LayoutConfig['density']) ?? 'comfortable',
+    authStyle: validateAuthStyle(process.env.LAYOUT_AUTH_STYLE),
+    navStyle: validateNavStyle(process.env.LAYOUT_NAV_STYLE),
+    density: validateDensity(process.env.LAYOUT_DENSITY),
   };
 }

--- a/src/lib/color-utils.ts
+++ b/src/lib/color-utils.ts
@@ -1,0 +1,88 @@
+/**
+ * Color Utility Functions
+ *
+ * Derive secondary colors from primary brand color.
+ */
+
+/**
+ * Check if a string is a valid hex color
+ */
+export function isValidHex(hex: string): boolean {
+  return /^#([0-9A-Fa-f]{3}|[0-9A-Fa-f]{6})$/.test(hex);
+}
+
+/**
+ * Normalize 3-digit hex to 6-digit
+ */
+function normalizeHex(hex: string): string {
+  if (hex.length === 4) {
+    return `#${hex[1]}${hex[1]}${hex[2]}${hex[2]}${hex[3]}${hex[3]}`;
+  }
+  return hex;
+}
+
+/**
+ * Parse hex color to RGB components
+ */
+function hexToRgb(hex: string): { r: number; g: number; b: number } | null {
+  if (!isValidHex(hex)) return null;
+
+  const normalized = normalizeHex(hex);
+  const result = /^#([0-9A-Fa-f]{2})([0-9A-Fa-f]{2})([0-9A-Fa-f]{2})$/.exec(
+    normalized
+  );
+
+  if (!result) return null;
+
+  return {
+    r: parseInt(result[1], 16),
+    g: parseInt(result[2], 16),
+    b: parseInt(result[3], 16),
+  };
+}
+
+/**
+ * Convert RGB to hex
+ */
+function rgbToHex(r: number, g: number, b: number): string {
+  const toHex = (n: number) => {
+    const clamped = Math.max(0, Math.min(255, Math.round(n)));
+    return clamped.toString(16).padStart(2, '0');
+  };
+
+  return `#${toHex(r)}${toHex(g)}${toHex(b)}`;
+}
+
+/**
+ * Darken a hex color by a percentage
+ *
+ * @param hex - Hex color (e.g., "#3b82f6")
+ * @param percent - Amount to darken (0-100)
+ * @returns Darkened hex color
+ */
+export function darken(hex: string, percent: number): string {
+  const rgb = hexToRgb(hex);
+  if (!rgb) return hex;
+
+  const factor = 1 - percent / 100;
+  return rgbToHex(rgb.r * factor, rgb.g * factor, rgb.b * factor);
+}
+
+/**
+ * Lighten a hex color by a percentage
+ *
+ * @param hex - Hex color (e.g., "#3b82f6")
+ * @param percent - Amount to lighten (0-100)
+ * @returns Lightened hex color
+ */
+export function lighten(hex: string, percent: number): string {
+  const rgb = hexToRgb(hex);
+  if (!rgb) return hex;
+
+  const factor = percent / 100;
+  return rgbToHex(
+    rgb.r + (255 - rgb.r) * factor,
+    rgb.g + (255 - rgb.g) * factor,
+    rgb.b + (255 - rgb.b) * factor
+  );
+}

--- a/src/lib/color-utils.ts
+++ b/src/lib/color-utils.ts
@@ -62,7 +62,12 @@ function rgbToHex(r: number, g: number, b: number): string {
  */
 export function darken(hex: string, percent: number): string {
   const rgb = hexToRgb(hex);
-  if (!rgb) return hex;
+  if (!rgb) {
+    if (process.env.NODE_ENV === 'development') {
+      console.warn(`darken(): Invalid hex color "${hex}". Returning original value.`);
+    }
+    return hex;
+  }
 
   const factor = 1 - percent / 100;
   return rgbToHex(rgb.r * factor, rgb.g * factor, rgb.b * factor);
@@ -77,7 +82,12 @@ export function darken(hex: string, percent: number): string {
  */
 export function lighten(hex: string, percent: number): string {
   const rgb = hexToRgb(hex);
-  if (!rgb) return hex;
+  if (!rgb) {
+    if (process.env.NODE_ENV === 'development') {
+      console.warn(`lighten(): Invalid hex color "${hex}". Returning original value.`);
+    }
+    return hex;
+  }
 
   const factor = percent / 100;
   return rgbToHex(

--- a/tests/unit/branding.spec.ts
+++ b/tests/unit/branding.spec.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+describe('branding', () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    vi.resetModules();
+    process.env = { ...originalEnv };
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  describe('getBranding', () => {
+    it('should return defaults when no env vars set', async () => {
+      const { getBranding } = await import('@/lib/branding');
+      const branding = getBranding();
+
+      expect(branding.name).toBe('SocleStack');
+      expect(branding.logoUrl).toBe('/logo.svg');
+      expect(branding.faviconUrl).toBe('/favicon.ico');
+      expect(branding.primaryColor).toBe('#3b82f6');
+    });
+
+    it('should read from environment variables', async () => {
+      process.env.BRAND_NAME = 'My App';
+      process.env.BRAND_LOGO_URL = '/custom-logo.png';
+      process.env.BRAND_FAVICON_URL = '/custom-favicon.ico';
+      process.env.BRAND_PRIMARY_COLOR = '#ff0000';
+
+      const { getBranding } = await import('@/lib/branding');
+      const branding = getBranding();
+
+      expect(branding.name).toBe('My App');
+      expect(branding.logoUrl).toBe('/custom-logo.png');
+      expect(branding.faviconUrl).toBe('/custom-favicon.ico');
+      expect(branding.primaryColor).toBe('#ff0000');
+    });
+  });
+
+  describe('getLayout', () => {
+    it('should return defaults when no env vars set', async () => {
+      const { getLayout } = await import('@/lib/branding');
+      const layout = getLayout();
+
+      expect(layout.authStyle).toBe('centered');
+      expect(layout.navStyle).toBe('top');
+      expect(layout.density).toBe('comfortable');
+    });
+
+    it('should read layout options from environment', async () => {
+      process.env.LAYOUT_AUTH_STYLE = 'split';
+      process.env.LAYOUT_NAV_STYLE = 'sidebar';
+      process.env.LAYOUT_DENSITY = 'compact';
+
+      const { getLayout } = await import('@/lib/branding');
+      const layout = getLayout();
+
+      expect(layout.authStyle).toBe('split');
+      expect(layout.navStyle).toBe('sidebar');
+      expect(layout.density).toBe('compact');
+    });
+  });
+});

--- a/tests/unit/color-utils.spec.ts
+++ b/tests/unit/color-utils.spec.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect } from 'vitest';
+import { darken, lighten, isValidHex } from '@/lib/color-utils';
+
+describe('color-utils', () => {
+  describe('isValidHex', () => {
+    it('should validate 6-digit hex colors', () => {
+      expect(isValidHex('#3b82f6')).toBe(true);
+      expect(isValidHex('#FF0000')).toBe(true);
+    });
+
+    it('should validate 3-digit hex colors', () => {
+      expect(isValidHex('#fff')).toBe(true);
+      expect(isValidHex('#F00')).toBe(true);
+    });
+
+    it('should reject invalid colors', () => {
+      expect(isValidHex('red')).toBe(false);
+      expect(isValidHex('#gggggg')).toBe(false);
+      expect(isValidHex('3b82f6')).toBe(false);
+    });
+  });
+
+  describe('darken', () => {
+    it('should darken a color by percentage', () => {
+      const result = darken('#3b82f6', 10);
+      expect(result).toMatch(/^#[0-9a-f]{6}$/i);
+      // Result should be darker (lower RGB values)
+    });
+
+    it('should return original for invalid hex', () => {
+      expect(darken('invalid', 10)).toBe('invalid');
+    });
+
+    it('should clamp to black at 100%', () => {
+      expect(darken('#ffffff', 100)).toBe('#000000');
+    });
+  });
+
+  describe('lighten', () => {
+    it('should lighten a color by percentage', () => {
+      const result = lighten('#3b82f6', 10);
+      expect(result).toMatch(/^#[0-9a-f]{6}$/i);
+    });
+
+    it('should return original for invalid hex', () => {
+      expect(lighten('invalid', 10)).toBe('invalid');
+    });
+
+    it('should clamp to white at 100%', () => {
+      expect(lighten('#000000', 100)).toBe('#ffffff');
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Add branding configuration module with env-based customization (name, logo, colors)
- Add color utility functions for deriving hover/light variants from primary color
- Implement CSS variable injection in root layout for Tailwind v4 theming
- Add three auth layout variants (centered, split, fullpage) switchable via env
- Add two navigation layout variants (top, sidebar) switchable via env
- Update UI components (button, input) to use brand colors

Closes #294, #295, #296, #297, #298, #299, #300, #301, #302

## Test plan
- [x] Unit tests pass for branding.spec.ts and color-utils.spec.ts
- [ ] Verify auth layouts by setting `LAYOUT_AUTH_STYLE=centered|split|fullpage`
- [ ] Verify nav layouts by setting `LAYOUT_NAV_STYLE=top|sidebar`
- [ ] Verify brand colors by setting `BRAND_PRIMARY_COLOR=#hexvalue`

🤖 Generated with [Claude Code](https://claude.ai/code)