### PR TITLE
chore(theming): follow-up improvements

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -96,6 +96,3 @@ TEST_DATABASE_URL=postgresql://soclestack:soclestack123@localhost:5432/soclestac
 
 # Navigation style: top | sidebar
 # LAYOUT_NAV_STYLE=top
-
-# UI density: compact | comfortable
-# LAYOUT_DENSITY=comfortable

--- a/src/lib/branding.ts
+++ b/src/lib/branding.ts
@@ -1,8 +1,7 @@
 /**
  * Branding Configuration
  *
- * Reads instance-level branding from environment variables.
- * Future: Will support org-level branding from database.
+ * Reads instance-level branding and layout from environment variables.
  */
 
 export interface BrandingConfig {
@@ -15,12 +14,10 @@ export interface BrandingConfig {
 export interface LayoutConfig {
   authStyle: 'centered' | 'split' | 'fullpage';
   navStyle: 'top' | 'sidebar';
-  density: 'compact' | 'comfortable';
 }
 
 const VALID_AUTH_STYLES = ['centered', 'split', 'fullpage'] as const;
 const VALID_NAV_STYLES = ['top', 'sidebar'] as const;
-const VALID_DENSITIES = ['compact', 'comfortable'] as const;
 
 function validateAuthStyle(
   value: string | undefined
@@ -50,28 +47,10 @@ function validateNavStyle(
   return 'top';
 }
 
-function validateDensity(
-  value: string | undefined
-): LayoutConfig['density'] {
-  if (value && VALID_DENSITIES.includes(value as LayoutConfig['density'])) {
-    return value as LayoutConfig['density'];
-  }
-  if (value) {
-    console.warn(
-      `Invalid LAYOUT_DENSITY "${value}". Valid options: ${VALID_DENSITIES.join(', ')}. Using default "comfortable".`
-    );
-  }
-  return 'comfortable';
-}
-
 /**
- * Get branding configuration
- *
- * @param orgId - Future: org ID for org-specific branding
- * @returns Branding config (currently instance-level only)
+ * Get branding configuration from environment variables
  */
-export function getBranding(_orgId?: string): BrandingConfig {
-  // Future: Check DB for org-specific branding first
+export function getBranding(): BrandingConfig {
   return {
     name: process.env.BRAND_NAME ?? 'SocleStack',
     logoUrl: process.env.BRAND_LOGO_URL ?? '/logo.svg',
@@ -87,6 +66,5 @@ export function getLayout(): LayoutConfig {
   return {
     authStyle: validateAuthStyle(process.env.LAYOUT_AUTH_STYLE),
     navStyle: validateNavStyle(process.env.LAYOUT_NAV_STYLE),
-    density: validateDensity(process.env.LAYOUT_DENSITY),
   };
 }

--- a/tests/unit/branding.spec.ts
+++ b/tests/unit/branding.spec.ts
@@ -46,20 +46,45 @@ describe('branding', () => {
 
       expect(layout.authStyle).toBe('centered');
       expect(layout.navStyle).toBe('top');
-      expect(layout.density).toBe('comfortable');
     });
 
     it('should read layout options from environment', async () => {
       process.env.LAYOUT_AUTH_STYLE = 'split';
       process.env.LAYOUT_NAV_STYLE = 'sidebar';
-      process.env.LAYOUT_DENSITY = 'compact';
 
       const { getLayout } = await import('@/lib/branding');
       const layout = getLayout();
 
       expect(layout.authStyle).toBe('split');
       expect(layout.navStyle).toBe('sidebar');
-      expect(layout.density).toBe('compact');
+    });
+
+    it('should warn and use default for invalid LAYOUT_AUTH_STYLE', async () => {
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      process.env.LAYOUT_AUTH_STYLE = 'invalid';
+
+      const { getLayout } = await import('@/lib/branding');
+      const layout = getLayout();
+
+      expect(layout.authStyle).toBe('centered');
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining('Invalid LAYOUT_AUTH_STYLE "invalid"')
+      );
+      warnSpy.mockRestore();
+    });
+
+    it('should warn and use default for invalid LAYOUT_NAV_STYLE', async () => {
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      process.env.LAYOUT_NAV_STYLE = 'invalid';
+
+      const { getLayout } = await import('@/lib/branding');
+      const layout = getLayout();
+
+      expect(layout.navStyle).toBe('top');
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining('Invalid LAYOUT_NAV_STYLE "invalid"')
+      );
+      warnSpy.mockRestore();
     });
   });
 });


### PR DESCRIPTION
## Summary
- Add tests for validation warning behavior (invalid env values)
- Remove unused density config from LayoutConfig interface
- Remove unused `_orgId` parameter from `getBranding()`
- Clean up .env.example

Closes #304

## Test plan
- [x] All existing tests pass
- [x] New validation warning tests pass
- [x] Build passes

🤖 Generated with [Claude Code](https://claude.ai/code)