### PR TITLE
test(e2e): add 2FA authentication flow tests

### DIFF
--- a/tests/e2e/auth/two-factor.spec.ts
+++ b/tests/e2e/auth/two-factor.spec.ts
@@ -1,0 +1,470 @@
+import { test, expect } from '@playwright/test';
+import { LoginPage } from '../../pages/LoginPage';
+import { TwoFactorSetupPage } from '../../pages/TwoFactorPage';
+import { AuthHelpers } from '../../utils/auth-helpers';
+import { DatabaseHelpers } from '../../utils/database-helpers';
+import {
+  generateTOTPCode,
+  generateInvalidTOTPCode,
+  waitForFreshTOTPWindow,
+} from '../../utils/totp-helpers';
+
+test.describe('Two-Factor Authentication', () => {
+  let loginPage: LoginPage;
+
+  test.beforeEach(async ({ page }) => {
+    loginPage = new LoginPage(page);
+    await DatabaseHelpers.setupTestUsers();
+  });
+
+  test.afterEach(async ({ page }) => {
+    try {
+      const isAuth = await AuthHelpers.isAuthenticated(page);
+      if (isAuth) {
+        await AuthHelpers.logout(page);
+      }
+    } catch {
+      // Ignore logout errors in cleanup
+    }
+  });
+
+  test.describe('2FA Setup Flow', () => {
+    test('should display QR code and manual entry key during setup', async ({
+      page,
+    }) => {
+      // Login as regular user first
+      await AuthHelpers.loginAsUser(page);
+
+      const setupPage = new TwoFactorSetupPage(page);
+      await setupPage.goto();
+
+      await test.step('Start 2FA setup', async () => {
+        await setupPage.startSetup();
+      });
+
+      await test.step('Verify QR code is displayed', async () => {
+        await expect(setupPage.qrCode).toBeVisible();
+      });
+
+      await test.step('Verify manual entry key is available', async () => {
+        const manualKey = await setupPage.getManualKey();
+        expect(manualKey).toBeTruthy();
+        expect(manualKey.length).toBeGreaterThan(10);
+      });
+    });
+
+    test('should display backup codes during setup', async ({ page }) => {
+      await AuthHelpers.loginAsUser(page);
+
+      const setupPage = new TwoFactorSetupPage(page);
+      await setupPage.goto();
+      await setupPage.startSetup();
+
+      await test.step('Verify backup codes are displayed', async () => {
+        const backupCodes = await setupPage.getBackupCodes();
+        expect(backupCodes.length).toBeGreaterThanOrEqual(8);
+      });
+    });
+
+    test('should enable 2FA with valid TOTP code', async ({ page }) => {
+      await AuthHelpers.loginAsUser(page);
+
+      const setupPage = new TwoFactorSetupPage(page);
+      await setupPage.goto();
+
+      await test.step('Complete 2FA setup', async () => {
+        await waitForFreshTOTPWindow();
+        await setupPage.performFullSetup(generateTOTPCode);
+      });
+
+      await test.step('Verify 2FA is enabled', async () => {
+        await setupPage.assertEnabled();
+      });
+
+      await test.step('Verify database state', async () => {
+        const has2FA = await DatabaseHelpers.has2FAEnabled('user@test.com');
+        expect(has2FA).toBe(true);
+      });
+    });
+
+    test('should reject invalid TOTP code during setup', async ({ page }) => {
+      await AuthHelpers.loginAsUser(page);
+
+      const setupPage = new TwoFactorSetupPage(page);
+      await setupPage.goto();
+      await setupPage.startSetup();
+      await setupPage.proceedToVerification();
+
+      await test.step('Enter invalid code', async () => {
+        await setupPage.completeSetup(generateInvalidTOTPCode());
+      });
+
+      await test.step('Verify error is shown', async () => {
+        await setupPage.assertErrorMessage('Invalid');
+      });
+
+      await test.step('Verify 2FA is not enabled', async () => {
+        const has2FA = await DatabaseHelpers.has2FAEnabled('user@test.com');
+        expect(has2FA).toBe(false);
+      });
+    });
+
+    test('should allow canceling 2FA setup', async ({ page }) => {
+      await AuthHelpers.loginAsUser(page);
+
+      const setupPage = new TwoFactorSetupPage(page);
+      await setupPage.goto();
+      await setupPage.startSetup();
+
+      await test.step('Cancel setup', async () => {
+        await setupPage.cancelSetup();
+      });
+
+      await test.step('Verify 2FA is not enabled', async () => {
+        const has2FA = await DatabaseHelpers.has2FAEnabled('user@test.com');
+        expect(has2FA).toBe(false);
+      });
+    });
+  });
+
+  test.describe('2FA Login Flow', () => {
+    test.beforeEach(async () => {
+      // Ensure user has 2FA enabled
+      await DatabaseHelpers.disable2FA('user@test.com');
+    });
+
+    test('should redirect to 2FA challenge after password login', async ({
+      page,
+    }) => {
+      // Enable 2FA for user
+      const { secret } = await DatabaseHelpers.enable2FA('user@test.com');
+
+      await test.step('Login with password', async () => {
+        await loginPage.goto();
+        await loginPage.fillEmail('user@test.com');
+        await loginPage.fillPassword('UserTest123!');
+        await loginPage.submitLogin();
+      });
+
+      await test.step('Verify 2FA challenge is shown', async () => {
+        // The login form shows 2FA input inline
+        await expect(
+          page.locator(
+            '[data-testid="2fa-code-input"], input[inputmode="numeric"]'
+          )
+        ).toBeVisible({ timeout: 10000 });
+      });
+    });
+
+    test('should complete login with valid TOTP code', async ({ page }) => {
+      const { secret } = await DatabaseHelpers.enable2FA('user@test.com');
+
+      await test.step('Login and enter 2FA code', async () => {
+        await loginPage.goto();
+        await loginPage.login('user@test.com', 'UserTest123!');
+
+        // Wait for 2FA input to appear
+        const codeInput = page.locator(
+          '[data-testid="2fa-code-input"], input[inputmode="numeric"]'
+        );
+        await expect(codeInput).toBeVisible({ timeout: 10000 });
+
+        // Generate and enter valid code
+        await waitForFreshTOTPWindow();
+        const code = generateTOTPCode(secret);
+        await codeInput.fill(code);
+
+        // Submit
+        await page
+          .locator('[data-testid="2fa-submit"], button:has-text("Verify")')
+          .click();
+      });
+
+      await test.step('Verify login successful', async () => {
+        await expect(page).toHaveURL(/.*\/dashboard/, { timeout: 15000 });
+      });
+    });
+
+    test('should reject invalid TOTP code during login', async ({ page }) => {
+      await DatabaseHelpers.enable2FA('user@test.com');
+
+      await test.step('Login and enter invalid 2FA code', async () => {
+        await loginPage.goto();
+        await loginPage.login('user@test.com', 'UserTest123!');
+
+        const codeInput = page.locator(
+          '[data-testid="2fa-code-input"], input[inputmode="numeric"]'
+        );
+        await expect(codeInput).toBeVisible({ timeout: 10000 });
+
+        await codeInput.fill(generateInvalidTOTPCode());
+        await page
+          .locator('[data-testid="2fa-submit"], button:has-text("Verify")')
+          .click();
+      });
+
+      await test.step('Verify error message is shown', async () => {
+        await expect(
+          page.locator('[data-testid="error-message"], [data-testid="2fa-error"]')
+        ).toBeVisible();
+      });
+
+      await test.step('Verify still on login page', async () => {
+        await expect(page).toHaveURL(/.*\/login/);
+      });
+    });
+
+    test('should allow login with backup code', async ({ page }) => {
+      const { backupCodes } = await DatabaseHelpers.enable2FA('user@test.com');
+      const backupCode = backupCodes[0];
+
+      await test.step('Login and switch to backup code', async () => {
+        await loginPage.goto();
+        await loginPage.login('user@test.com', 'UserTest123!');
+
+        const codeInput = page.locator(
+          '[data-testid="2fa-code-input"], input[inputmode="numeric"]'
+        );
+        await expect(codeInput).toBeVisible({ timeout: 10000 });
+
+        // Click "Use backup code" link
+        await page
+          .locator(
+            '[data-testid="use-backup-code"], button:has-text("backup code")'
+          )
+          .click();
+      });
+
+      await test.step('Enter backup code', async () => {
+        const backupInput = page.locator(
+          '[data-testid="backup-code-input"], input[placeholder*="backup"]'
+        );
+        await expect(backupInput).toBeVisible();
+        await backupInput.fill(backupCode);
+
+        await page
+          .locator('[data-testid="2fa-submit"], button:has-text("Verify")')
+          .click();
+      });
+
+      await test.step('Verify login successful', async () => {
+        await expect(page).toHaveURL(/.*\/dashboard/, { timeout: 15000 });
+      });
+    });
+
+    test('should show rate limiting after multiple failed attempts', async ({
+      page,
+    }) => {
+      await DatabaseHelpers.enable2FA('user@test.com');
+      const maxAttempts = 5;
+
+      await test.step('Make multiple failed 2FA attempts', async () => {
+        await loginPage.goto();
+        await loginPage.login('user@test.com', 'UserTest123!');
+
+        const codeInput = page.locator(
+          '[data-testid="2fa-code-input"], input[inputmode="numeric"]'
+        );
+        await expect(codeInput).toBeVisible({ timeout: 10000 });
+
+        for (let i = 0; i < maxAttempts; i++) {
+          await codeInput.clear();
+          await codeInput.fill(generateInvalidTOTPCode());
+          await page
+            .locator('[data-testid="2fa-submit"], button:has-text("Verify")')
+            .click();
+          await page.waitForTimeout(500);
+        }
+      });
+
+      await test.step('Verify rate limiting or lockout', async () => {
+        // Either rate limit message or locked out
+        const rateLimitOrLockout = page.locator(
+          '[data-testid="rate-limit-error"], [data-testid="error-message"]:has-text("too many"), [data-testid="error-message"]:has-text("locked")'
+        );
+        await expect(rateLimitOrLockout).toBeVisible({ timeout: 10000 });
+      });
+    });
+  });
+
+  test.describe('2FA Disable Flow', () => {
+    test('should disable 2FA with valid TOTP code', async ({ page }) => {
+      // Setup user with 2FA
+      const { secret } = await DatabaseHelpers.enable2FA('user@test.com');
+
+      // Login (need to complete 2FA to get to profile)
+      await loginPage.goto();
+      await loginPage.login('user@test.com', 'UserTest123!');
+
+      const codeInput = page.locator(
+        '[data-testid="2fa-code-input"], input[inputmode="numeric"]'
+      );
+      await expect(codeInput).toBeVisible({ timeout: 10000 });
+      await waitForFreshTOTPWindow();
+      await codeInput.fill(generateTOTPCode(secret));
+      await page
+        .locator('[data-testid="2fa-submit"], button:has-text("Verify")')
+        .click();
+
+      await expect(page).toHaveURL(/.*\/dashboard/, { timeout: 15000 });
+
+      const setupPage = new TwoFactorSetupPage(page);
+      await setupPage.goto();
+
+      await test.step('Disable 2FA', async () => {
+        await waitForFreshTOTPWindow();
+        const disableCode = generateTOTPCode(secret);
+        await setupPage.disable(disableCode);
+      });
+
+      await test.step('Verify 2FA is disabled', async () => {
+        await setupPage.assertDisabled();
+      });
+
+      await test.step('Verify database state', async () => {
+        const has2FA = await DatabaseHelpers.has2FAEnabled('user@test.com');
+        expect(has2FA).toBe(false);
+      });
+    });
+
+    test('should reject invalid code when disabling 2FA', async ({ page }) => {
+      const { secret } = await DatabaseHelpers.enable2FA('user@test.com');
+
+      // Login with 2FA
+      await loginPage.goto();
+      await loginPage.login('user@test.com', 'UserTest123!');
+      const codeInput = page.locator(
+        '[data-testid="2fa-code-input"], input[inputmode="numeric"]'
+      );
+      await expect(codeInput).toBeVisible({ timeout: 10000 });
+      await waitForFreshTOTPWindow();
+      await codeInput.fill(generateTOTPCode(secret));
+      await page
+        .locator('[data-testid="2fa-submit"], button:has-text("Verify")')
+        .click();
+      await expect(page).toHaveURL(/.*\/dashboard/, { timeout: 15000 });
+
+      const setupPage = new TwoFactorSetupPage(page);
+      await setupPage.goto();
+
+      await test.step('Attempt to disable with invalid code', async () => {
+        await setupPage.disable(generateInvalidTOTPCode());
+      });
+
+      await test.step('Verify error shown', async () => {
+        await setupPage.assertErrorMessage('Invalid');
+      });
+
+      await test.step('Verify 2FA is still enabled', async () => {
+        const has2FA = await DatabaseHelpers.has2FAEnabled('user@test.com');
+        expect(has2FA).toBe(true);
+      });
+    });
+
+    test('should skip 2FA challenge after disabling', async ({ page }) => {
+      const { secret } = await DatabaseHelpers.enable2FA('user@test.com');
+
+      // Login with 2FA
+      await loginPage.goto();
+      await loginPage.login('user@test.com', 'UserTest123!');
+      const codeInput = page.locator(
+        '[data-testid="2fa-code-input"], input[inputmode="numeric"]'
+      );
+      await expect(codeInput).toBeVisible({ timeout: 10000 });
+      await waitForFreshTOTPWindow();
+      await codeInput.fill(generateTOTPCode(secret));
+      await page
+        .locator('[data-testid="2fa-submit"], button:has-text("Verify")')
+        .click();
+      await expect(page).toHaveURL(/.*\/dashboard/, { timeout: 15000 });
+
+      // Disable 2FA
+      const setupPage = new TwoFactorSetupPage(page);
+      await setupPage.goto();
+      await waitForFreshTOTPWindow();
+      await setupPage.disable(generateTOTPCode(secret));
+      await setupPage.assertDisabled();
+
+      // Logout and login again
+      await AuthHelpers.logout(page);
+
+      await test.step('Login again without 2FA', async () => {
+        await loginPage.goto();
+        await loginPage.login('user@test.com', 'UserTest123!');
+      });
+
+      await test.step('Verify direct redirect to dashboard (no 2FA)', async () => {
+        await expect(page).toHaveURL(/.*\/dashboard/, { timeout: 15000 });
+        // Should NOT see 2FA input
+        await expect(
+          page.locator('[data-testid="2fa-code-input"]')
+        ).not.toBeVisible({ timeout: 3000 });
+      });
+    });
+  });
+
+  test.describe('2FA Edge Cases', () => {
+    test('should handle session expiry during 2FA', async ({ page }) => {
+      await DatabaseHelpers.enable2FA('user@test.com');
+
+      await test.step('Start login and get to 2FA', async () => {
+        await loginPage.goto();
+        await loginPage.login('user@test.com', 'UserTest123!');
+        const codeInput = page.locator(
+          '[data-testid="2fa-code-input"], input[inputmode="numeric"]'
+        );
+        await expect(codeInput).toBeVisible({ timeout: 10000 });
+      });
+
+      await test.step('Clear cookies to simulate expiry', async () => {
+        await page.context().clearCookies();
+      });
+
+      await test.step('Submit code and verify redirect to login', async () => {
+        const codeInput = page.locator(
+          '[data-testid="2fa-code-input"], input[inputmode="numeric"]'
+        );
+        await codeInput.fill('123456');
+        await page
+          .locator('[data-testid="2fa-submit"], button:has-text("Verify")')
+          .click();
+
+        // Should show error or redirect to login
+        const errorOrLogin = await Promise.race([
+          page.waitForURL('**/login', { timeout: 5000 }).then(() => 'login'),
+          page
+            .locator('[data-testid="error-message"]')
+            .waitFor({ timeout: 5000 })
+            .then(() => 'error'),
+        ]);
+
+        expect(['login', 'error']).toContain(errorOrLogin);
+      });
+    });
+
+    test('should allow user to cancel 2FA and return to login', async ({
+      page,
+    }) => {
+      await DatabaseHelpers.enable2FA('user@test.com');
+
+      await test.step('Start login and get to 2FA', async () => {
+        await loginPage.goto();
+        await loginPage.login('user@test.com', 'UserTest123!');
+        const codeInput = page.locator(
+          '[data-testid="2fa-code-input"], input[inputmode="numeric"]'
+        );
+        await expect(codeInput).toBeVisible({ timeout: 10000 });
+      });
+
+      await test.step('Cancel 2FA', async () => {
+        const cancelButton = page.locator(
+          '[data-testid="2fa-cancel"], button:has-text("Cancel")'
+        );
+        if (await cancelButton.isVisible()) {
+          await cancelButton.click();
+          await expect(page).toHaveURL(/.*\/login/);
+        }
+      });
+    });
+  });
+});

--- a/tests/pages/TwoFactorPage.ts
+++ b/tests/pages/TwoFactorPage.ts
@@ -1,0 +1,345 @@
+import { Page, Locator, expect } from '@playwright/test';
+import { BasePage } from './BasePage';
+
+/**
+ * Page object for 2FA challenge page (/auth/two-factor)
+ */
+export class TwoFactorPage extends BasePage {
+  // Challenge page elements
+  readonly codeInput: Locator;
+  readonly submitButton: Locator;
+  readonly cancelButton: Locator;
+  readonly useBackupCodeLink: Locator;
+  readonly backupCodeInput: Locator;
+  readonly useAuthenticatorLink: Locator;
+
+  constructor(page: Page) {
+    super(page);
+
+    this.codeInput = this.page.locator(
+      '[data-testid="2fa-code-input"], input[inputmode="numeric"]'
+    );
+    this.submitButton = this.page.locator(
+      '[data-testid="2fa-submit"], button:has-text("Verify")'
+    );
+    this.cancelButton = this.page.locator(
+      '[data-testid="2fa-cancel"], button:has-text("Cancel")'
+    );
+    this.useBackupCodeLink = this.page.locator(
+      '[data-testid="use-backup-code"], button:has-text("Use backup code")'
+    );
+    this.backupCodeInput = this.page.locator('[data-testid="backup-code-input"]');
+    this.useAuthenticatorLink = this.page.locator(
+      '[data-testid="use-authenticator"], button:has-text("Use authenticator")'
+    );
+  }
+
+  /**
+   * Navigate to 2FA page with token
+   */
+  async goto(token: string, returnTo: string = '/dashboard'): Promise<void> {
+    await this.navigateTo(
+      `/auth/two-factor?token=${token}&returnTo=${encodeURIComponent(returnTo)}`
+    );
+    await this.waitForFormToLoad();
+  }
+
+  /**
+   * Wait for 2FA form to be ready
+   */
+  async waitForFormToLoad(): Promise<void> {
+    await expect(this.codeInput).toBeVisible({ timeout: 10000 });
+  }
+
+  /**
+   * Enter TOTP code
+   */
+  async enterCode(code: string): Promise<void> {
+    await this.codeInput.clear();
+    await this.codeInput.fill(code);
+  }
+
+  /**
+   * Submit the 2FA code
+   */
+  async submit(): Promise<void> {
+    await this.submitButton.click();
+  }
+
+  /**
+   * Complete 2FA verification with code
+   */
+  async verify(code: string): Promise<void> {
+    await this.enterCode(code);
+    await this.submit();
+  }
+
+  /**
+   * Cancel 2FA and return to login
+   */
+  async cancel(): Promise<void> {
+    await this.cancelButton.click();
+    await this.page.waitForURL('**/login');
+  }
+
+  /**
+   * Switch to backup code mode
+   */
+  async switchToBackupCode(): Promise<void> {
+    await this.useBackupCodeLink.click();
+    await expect(this.backupCodeInput).toBeVisible();
+  }
+
+  /**
+   * Switch back to authenticator mode
+   */
+  async switchToAuthenticator(): Promise<void> {
+    await this.useAuthenticatorLink.click();
+    await expect(this.codeInput).toBeVisible();
+  }
+
+  /**
+   * Enter and submit backup code
+   */
+  async verifyWithBackupCode(backupCode: string): Promise<void> {
+    await this.switchToBackupCode();
+    await this.backupCodeInput.clear();
+    await this.backupCodeInput.fill(backupCode);
+    await this.submit();
+  }
+
+  /**
+   * Assert error message is displayed
+   */
+  async assertError(expectedMessage?: string): Promise<void> {
+    await expect(this.errorMessage).toBeVisible();
+    if (expectedMessage) {
+      await expect(this.errorMessage).toContainText(expectedMessage);
+    }
+  }
+
+  /**
+   * Assert successful verification (redirected away from 2FA page)
+   */
+  async assertVerificationSuccess(expectedUrl: string = '/dashboard'): Promise<void> {
+    await this.page.waitForURL(`**${expectedUrl}`, { timeout: 10000 });
+  }
+
+  /**
+   * Assert rate limit error
+   */
+  async assertRateLimitError(): Promise<void> {
+    await expect(
+      this.page.locator('[data-testid="rate-limit-error"], [data-testid="error-message"]')
+    ).toBeVisible();
+    const errorText = await this.errorMessage.textContent();
+    expect(errorText?.toLowerCase()).toContain('too many');
+  }
+}
+
+/**
+ * Page object for 2FA setup flow (in profile/security)
+ */
+export class TwoFactorSetupPage extends BasePage {
+  // Setup elements
+  readonly setupButton: Locator;
+  readonly qrCode: Locator;
+  readonly manualKeyDisplay: Locator;
+  readonly manualKeyToggle: Locator;
+  readonly backupCodesDisplay: Locator;
+  readonly copyCodesButton: Locator;
+  readonly downloadCodesButton: Locator;
+  readonly savedCodesButton: Locator;
+  readonly verifyCodeInput: Locator;
+  readonly enableButton: Locator;
+  readonly cancelButton: Locator;
+  readonly backButton: Locator;
+
+  // Disable elements
+  readonly disableButton: Locator;
+  readonly disableCodeInput: Locator;
+  readonly confirmDisableButton: Locator;
+
+  // Status elements
+  readonly twoFactorStatus: Locator;
+  readonly enabledBadge: Locator;
+  readonly disabledBadge: Locator;
+
+  constructor(page: Page) {
+    super(page);
+
+    // Setup flow
+    this.setupButton = this.page.locator(
+      '[data-testid="2fa-setup-button"], button:has-text("Set up two-factor")'
+    );
+    this.qrCode = this.page.locator('[data-testid="2fa-qr-code"], img[alt*="QR"]');
+    this.manualKeyDisplay = this.page.locator('[data-testid="manual-entry-key"], code');
+    this.manualKeyToggle = this.page.locator(
+      '[data-testid="manual-key-toggle"], summary:has-text("manually")'
+    );
+    this.backupCodesDisplay = this.page.locator('[data-testid="backup-codes"]');
+    this.copyCodesButton = this.page.locator(
+      '[data-testid="copy-codes-button"], button:has-text("Copy")'
+    );
+    this.downloadCodesButton = this.page.locator(
+      '[data-testid="download-codes-button"], button:has-text("Download")'
+    );
+    this.savedCodesButton = this.page.locator(
+      '[data-testid="saved-codes-button"], button:has-text("saved my backup")'
+    );
+    this.verifyCodeInput = this.page.locator(
+      '[data-testid="verify-code-input"], input[pattern*="0-9"]'
+    );
+    this.enableButton = this.page.locator(
+      '[data-testid="enable-2fa-button"], button:has-text("Enable 2FA")'
+    );
+    this.cancelButton = this.page.locator(
+      '[data-testid="cancel-setup-button"], button:has-text("Cancel")'
+    );
+    this.backButton = this.page.locator(
+      '[data-testid="back-button"], button:has-text("Back")'
+    );
+
+    // Disable flow
+    this.disableButton = this.page.locator(
+      '[data-testid="disable-2fa-button"], button:has-text("Disable")'
+    );
+    this.disableCodeInput = this.page.locator('[data-testid="disable-code-input"]');
+    this.confirmDisableButton = this.page.locator(
+      '[data-testid="confirm-disable-button"]'
+    );
+
+    // Status
+    this.twoFactorStatus = this.page.locator('[data-testid="2fa-status"]');
+    this.enabledBadge = this.page.locator(
+      '[data-testid="2fa-enabled-badge"], :has-text("Enabled")'
+    );
+    this.disabledBadge = this.page.locator(
+      '[data-testid="2fa-disabled-badge"], :has-text("Disabled")'
+    );
+  }
+
+  /**
+   * Navigate to security settings where 2FA setup is located
+   */
+  async goto(): Promise<void> {
+    await this.navigateTo('/profile/security');
+  }
+
+  /**
+   * Start 2FA setup flow
+   */
+  async startSetup(): Promise<void> {
+    await this.setupButton.click();
+    await expect(this.qrCode).toBeVisible({ timeout: 10000 });
+  }
+
+  /**
+   * Get the manual entry key for TOTP
+   */
+  async getManualKey(): Promise<string> {
+    // Click to expand if needed
+    const isVisible = await this.manualKeyDisplay.isVisible();
+    if (!isVisible) {
+      await this.manualKeyToggle.click();
+    }
+    const key = await this.manualKeyDisplay.textContent();
+    return key?.trim() || '';
+  }
+
+  /**
+   * Get backup codes from the display
+   */
+  async getBackupCodes(): Promise<string[]> {
+    const codesContainer = this.page.locator(
+      '[data-testid="backup-codes"] div, .backup-codes div'
+    );
+    const codeElements = await codesContainer.all();
+    const codes: string[] = [];
+
+    for (const element of codeElements) {
+      const text = await element.textContent();
+      if (text && /^[A-Za-z0-9]{8}$/.test(text.trim())) {
+        codes.push(text.trim());
+      }
+    }
+
+    return codes;
+  }
+
+  /**
+   * Proceed to verification step after saving backup codes
+   */
+  async proceedToVerification(): Promise<void> {
+    await this.savedCodesButton.click();
+    await expect(this.verifyCodeInput).toBeVisible();
+  }
+
+  /**
+   * Complete 2FA setup by entering verification code
+   */
+  async completeSetup(code: string): Promise<void> {
+    await this.verifyCodeInput.clear();
+    await this.verifyCodeInput.fill(code);
+    await this.enableButton.click();
+  }
+
+  /**
+   * Full setup flow from start to finish
+   */
+  async performFullSetup(generateCode: (secret: string) => string): Promise<{
+    secret: string;
+    backupCodes: string[];
+  }> {
+    await this.startSetup();
+
+    // Get the secret
+    const secret = await this.getManualKey();
+
+    // Get backup codes
+    const backupCodes = await this.getBackupCodes();
+
+    // Proceed to verification
+    await this.proceedToVerification();
+
+    // Generate and enter code
+    const code = generateCode(secret);
+    await this.completeSetup(code);
+
+    // Wait for success
+    await expect(this.successMessage).toBeVisible();
+
+    return { secret, backupCodes };
+  }
+
+  /**
+   * Disable 2FA
+   */
+  async disable(code: string): Promise<void> {
+    await this.disableButton.click();
+    await expect(this.disableCodeInput).toBeVisible();
+    await this.disableCodeInput.fill(code);
+    await this.confirmDisableButton.click();
+  }
+
+  /**
+   * Assert 2FA is enabled
+   */
+  async assertEnabled(): Promise<void> {
+    await expect(this.enabledBadge).toBeVisible();
+  }
+
+  /**
+   * Assert 2FA is disabled
+   */
+  async assertDisabled(): Promise<void> {
+    await expect(this.disabledBadge).toBeVisible();
+  }
+
+  /**
+   * Cancel setup and return
+   */
+  async cancelSetup(): Promise<void> {
+    await this.cancelButton.click();
+  }
+}

--- a/tests/utils/totp-helpers.ts
+++ b/tests/utils/totp-helpers.ts
@@ -1,0 +1,125 @@
+import * as OTPAuth from 'otpauth';
+
+/**
+ * TOTP Helper Utilities for E2E Tests
+ *
+ * Provides functions to generate valid TOTP codes for testing 2FA flows.
+ */
+
+export interface TOTPConfig {
+  issuer?: string;
+  algorithm?: string;
+  digits?: number;
+  period?: number;
+}
+
+const DEFAULT_CONFIG: TOTPConfig = {
+  issuer: 'SocleStack',
+  algorithm: 'SHA1',
+  digits: 6,
+  period: 30,
+};
+
+/**
+ * Generate a valid TOTP code from a secret
+ */
+export function generateTOTPCode(secret: string, config: TOTPConfig = {}): string {
+  const mergedConfig = { ...DEFAULT_CONFIG, ...config };
+
+  const totp = new OTPAuth.TOTP({
+    issuer: mergedConfig.issuer,
+    algorithm: mergedConfig.algorithm,
+    digits: mergedConfig.digits,
+    period: mergedConfig.period,
+    secret: OTPAuth.Secret.fromBase32(secret),
+  });
+
+  return totp.generate();
+}
+
+/**
+ * Generate a TOTP secret for testing
+ */
+export function generateTOTPSecret(): string {
+  const totp = new OTPAuth.TOTP({
+    issuer: DEFAULT_CONFIG.issuer,
+    algorithm: DEFAULT_CONFIG.algorithm,
+    digits: DEFAULT_CONFIG.digits,
+    period: DEFAULT_CONFIG.period,
+  });
+
+  return totp.secret.base32;
+}
+
+/**
+ * Verify a TOTP code against a secret
+ */
+export function verifyTOTPCode(
+  secret: string,
+  code: string,
+  config: TOTPConfig = {}
+): boolean {
+  const mergedConfig = { ...DEFAULT_CONFIG, ...config };
+
+  const totp = new OTPAuth.TOTP({
+    issuer: mergedConfig.issuer,
+    algorithm: mergedConfig.algorithm,
+    digits: mergedConfig.digits,
+    period: mergedConfig.period,
+    secret: OTPAuth.Secret.fromBase32(secret),
+  });
+
+  const delta = totp.validate({ token: code, window: 1 });
+  return delta !== null;
+}
+
+/**
+ * Generate an invalid TOTP code (for negative testing)
+ */
+export function generateInvalidTOTPCode(): string {
+  // Return a code that won't match any valid TOTP
+  return '000000';
+}
+
+/**
+ * Generate an expired TOTP code (from a different time window)
+ */
+export function generateExpiredTOTPCode(secret: string): string {
+  const totp = new OTPAuth.TOTP({
+    issuer: DEFAULT_CONFIG.issuer,
+    algorithm: DEFAULT_CONFIG.algorithm,
+    digits: DEFAULT_CONFIG.digits,
+    period: DEFAULT_CONFIG.period,
+    secret: OTPAuth.Secret.fromBase32(secret),
+  });
+
+  // Generate code from 5 periods ago (2.5 minutes in the past)
+  const pastTime = Math.floor(Date.now() / 1000) - 150;
+  return totp.generate({ timestamp: pastTime * 1000 });
+}
+
+/**
+ * Extract manual entry key from QR code data URL or setup response
+ */
+export function extractManualKey(setupResponse: {
+  manualEntryKey?: string;
+  secret?: string;
+}): string {
+  return setupResponse.manualEntryKey || setupResponse.secret || '';
+}
+
+/**
+ * Wait for the next TOTP window to avoid timing issues
+ * This ensures a fresh code that won't expire during the test
+ */
+export async function waitForFreshTOTPWindow(): Promise<void> {
+  const now = Date.now();
+  const currentPeriod = Math.floor(now / 30000);
+  const nextPeriodStart = (currentPeriod + 1) * 30000;
+  const waitTime = nextPeriodStart - now + 1000; // Add 1 second buffer
+
+  if (waitTime < 5000) {
+    // If we're close to the next period, wait for it
+    await new Promise((resolve) => setTimeout(resolve, waitTime));
+  }
+}


### PR DESCRIPTION
## Summary

Add comprehensive e2e tests for two-factor authentication (2FA) flow.

- Setup flow tests (QR code, backup codes, enable with TOTP)
- Login flow tests (2FA challenge, valid/invalid codes, backup codes)
- Disable flow tests (disable with code, skip 2FA after)
- Edge cases (session expiry, cancel)

## New Files

- `tests/e2e/auth/two-factor.spec.ts` - Main test file with ~15 test cases
- `tests/pages/TwoFactorPage.ts` - Page objects for 2FA challenge and setup
- `tests/utils/totp-helpers.ts` - TOTP code generation utilities for tests
- Updated `tests/utils/database-helpers.ts` - Added 2FA database helpers

## Test Plan

- [ ] Run `npm run test:e2e` to verify tests pass
- [ ] Manual verification: setup 2FA, login with 2FA, disable 2FA

Closes #307

🤖 Generated with [Claude Code](https://claude.com/claude-code)