### PR TITLE
test(e2e): use stricter backup code regex in TwoFactorPage

### DIFF
--- a/tests/pages/TwoFactorPage.ts
+++ b/tests/pages/TwoFactorPage.ts
@@ -281,7 +281,8 @@ export class TwoFactorSetupPage extends BasePage {
 
     for (const element of containerElements) {
       const text = await element.textContent();
-      if (text && /^[A-Za-z0-9]{8}$/.test(text.trim())) {
+      // Match exact backup code format: uppercase A-Z (excluding I,O) + digits 2-9 (excluding 0,1)
+      if (text && /^[A-HJ-NP-Z2-9]{8}$/.test(text.trim())) {
         codes.push(text.trim());
       }
     }


### PR DESCRIPTION
## Summary
- Updates backup code regex from `/^[A-Za-z0-9]{8}$/` to `/^[A-HJ-NP-Z2-9]{8}$/`
- Matches the exact character set used by the application's backup code generator
- Excludes confusing characters: I, O (letters) and 0, 1 (digits)

Closes #318

## Test plan
- [x] TypeScript compilation passes
- [x] Build succeeds
- [x] Regex matches actual backup code format from `src/lib/auth/backup-codes.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)