### PR TITLE
test(e2e): add API keys management E2E tests

### DIFF
--- a/src/components/profile/api-keys.tsx
+++ b/src/components/profile/api-keys.tsx
@@ -336,6 +336,7 @@ export function ApiKeys() {
               onClick={() => setShowCreateModal(true)}
               disabled={count >= limit}
               size="sm"
+              data-testid="create-api-key-button"
             >
               <Plus className="mr-1 h-4 w-4" />
               Create Key
@@ -347,7 +348,7 @@ export function ApiKeys() {
           {success && <Alert variant="success">{success}</Alert>}
 
           {keys.length === 0 ? (
-            <div className="py-8 text-center text-gray-500">
+            <div className="py-8 text-center text-gray-500" data-testid="empty-keys-message">
               <Key className="mx-auto mb-3 h-12 w-12 text-gray-300" />
               <p>No API keys yet</p>
               <p className="text-sm">
@@ -355,10 +356,12 @@ export function ApiKeys() {
               </p>
             </div>
           ) : (
-            <div className="space-y-3">
+            <div className="space-y-3" data-testid="api-keys-list">
               {keys.map((key) => (
                 <div
                   key={key.id}
+                  data-testid={`api-key-item-${key.id}`}
+                  data-key-name={key.name}
                   className={`flex items-center justify-between rounded-lg border p-4 ${
                     isExpired(key.expiresAt)
                       ? 'border-red-200 bg-red-50'
@@ -369,7 +372,7 @@ export function ApiKeys() {
                 >
                   <div className="min-w-0 flex-1">
                     <div className="flex items-center gap-2">
-                      <span className="truncate font-medium">{key.name}</span>
+                      <span className="truncate font-medium" data-testid="api-key-name">{key.name}</span>
                       <span
                         className={`rounded-full px-2 py-0.5 text-xs ${
                           key.permission === 'READ_WRITE'
@@ -412,6 +415,7 @@ export function ApiKeys() {
                       variant="ghost"
                       size="sm"
                       onClick={() => handleEdit(key)}
+                      data-testid="edit-api-key-button"
                     >
                       <Edit2 className="h-4 w-4" />
                     </Button>
@@ -421,6 +425,7 @@ export function ApiKeys() {
                       onClick={() => handleDelete(key)}
                       disabled={deletingId === key.id}
                       className="text-red-600 hover:bg-red-50 hover:text-red-700"
+                      data-testid="delete-api-key-button"
                     >
                       {deletingId === key.id ? (
                         <Loader2 className="h-4 w-4 animate-spin" />
@@ -448,7 +453,7 @@ export function ApiKeys() {
 
       {/* Create Key Modal */}
       {showCreateModal && (
-        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50" data-testid="create-key-modal">
           <div className="mx-4 w-full max-w-md rounded-lg bg-white p-6">
             <h3 className="mb-4 text-lg font-semibold">Create API Key</h3>
 
@@ -460,6 +465,7 @@ export function ApiKeys() {
                   onChange={(e) => setCreateName(e.target.value)}
                   placeholder="e.g., CI/CD Pipeline"
                   maxLength={50}
+                  data-testid="api-key-name-input"
                 />
               </div>
 
@@ -473,6 +479,7 @@ export function ApiKeys() {
                     setCreatePermission(e.target.value as ApiKeyPermission)
                   }
                   className="w-full rounded-md border px-3 py-2"
+                  data-testid="api-key-permission-select"
                 >
                   <option value="READ_ONLY">
                     Read-Only (GET requests only)
@@ -526,6 +533,7 @@ export function ApiKeys() {
                 variant="outline"
                 onClick={() => setShowCreateModal(false)}
                 className="flex-1"
+                data-testid="cancel-create-key-button"
               >
                 Cancel
               </Button>
@@ -533,6 +541,7 @@ export function ApiKeys() {
                 onClick={handleCreate}
                 disabled={creating || !createName.trim()}
                 className="flex-1"
+                data-testid="confirm-create-key-button"
               >
                 {creating ? (
                   <Loader2 className="h-4 w-4 animate-spin" />
@@ -547,7 +556,7 @@ export function ApiKeys() {
 
       {/* New Key Display Modal */}
       {newKey && (
-        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50" data-testid="new-key-modal">
           <div className="mx-4 w-full max-w-lg rounded-lg bg-white p-6">
             <h3 className="mb-2 text-lg font-semibold">Your New API Key</h3>
             <p className="mb-4 text-sm text-gray-600">
@@ -555,7 +564,7 @@ export function ApiKeys() {
               it again!
             </p>
 
-            <div className="rounded-lg bg-gray-100 p-4 font-mono text-sm break-all">
+            <div className="rounded-lg bg-gray-100 p-4 font-mono text-sm break-all" data-testid="new-api-key-value">
               {newKey}
             </div>
 
@@ -563,6 +572,7 @@ export function ApiKeys() {
               onClick={handleCopyKey}
               variant="outline"
               className="mt-3 w-full"
+              data-testid="copy-api-key-button"
             >
               {keyCopied ? (
                 <>
@@ -584,12 +594,13 @@ export function ApiKeys() {
                   checked={copyConfirmed}
                   onChange={(e) => setCopyConfirmed(e.target.checked)}
                   className="rounded"
+                  data-testid="copy-confirmed-checkbox"
                 />
                 I have copied my API key to a safe place
               </label>
             </div>
 
-            <Button onClick={handleCloseNewKeyModal} className="mt-4 w-full">
+            <Button onClick={handleCloseNewKeyModal} className="mt-4 w-full" data-testid="close-new-key-modal-button">
               Done
             </Button>
           </div>

--- a/tests/e2e/api/api-keys.spec.ts
+++ b/tests/e2e/api/api-keys.spec.ts
@@ -1,0 +1,275 @@
+import { test, expect } from '@playwright/test';
+import { ApiKeysPage } from '../../pages/ApiKeysPage';
+import { AuthHelpers } from '../../utils/auth-helpers';
+
+test.describe('API Keys Management', () => {
+  let apiKeysPage: ApiKeysPage;
+
+  test.beforeEach(async ({ page }) => {
+    // Login as regular user
+    await AuthHelpers.loginAsUser(page);
+
+    apiKeysPage = new ApiKeysPage(page);
+    await apiKeysPage.goto();
+  });
+
+  test.afterEach(async ({ page }) => {
+    // Clean up - logout
+    try {
+      await AuthHelpers.logout(page);
+    } catch {
+      // Ignore logout errors
+    }
+  });
+
+  test.describe('Create API Key', () => {
+    test('should create an API key with name and display secret once', async ({ page }) => {
+      const keyName = `Test Key ${Date.now()}`;
+
+      await test.step('Open create modal', async () => {
+        await apiKeysPage.openCreateModal();
+        await expect(apiKeysPage.createModal).toBeVisible();
+      });
+
+      let apiKey: string;
+      await test.step('Fill form and create key', async () => {
+        apiKey = await apiKeysPage.createKey(keyName);
+        expect(apiKey).toBeTruthy();
+        expect(apiKey.length).toBeGreaterThan(20); // API keys should be reasonably long
+      });
+
+      await test.step('Verify key is shown in new key modal', async () => {
+        await expect(apiKeysPage.newKeyModal).toBeVisible();
+        await expect(apiKeysPage.newKeyValue).toContainText(apiKey!.substring(0, 10));
+      });
+
+      await test.step('Close modal and verify key in list', async () => {
+        await apiKeysPage.closeNewKeyModal();
+        await apiKeysPage.assertKeyExists(keyName);
+      });
+
+      // Clean up - delete the key we created
+      await test.step('Cleanup - delete created key', async () => {
+        await apiKeysPage.deleteKey(keyName);
+      });
+    });
+
+    test('should show copy button functionality', async ({ page }) => {
+      const keyName = `Copy Test ${Date.now()}`;
+
+      await apiKeysPage.createKey(keyName);
+
+      await test.step('Verify copy button exists', async () => {
+        await expect(apiKeysPage.copyKeyButton).toBeVisible();
+        await expect(apiKeysPage.copyKeyButton).toContainText('Copy');
+      });
+
+      await test.step('Close modal', async () => {
+        await apiKeysPage.closeNewKeyModal();
+      });
+
+      // Clean up
+      await apiKeysPage.deleteKey(keyName);
+    });
+
+    test('should require confirmation checkbox to close modal without warning', async ({ page }) => {
+      const keyName = `Confirm Test ${Date.now()}`;
+
+      await apiKeysPage.createKey(keyName);
+
+      await test.step('Verify confirmation checkbox exists', async () => {
+        await expect(apiKeysPage.copyConfirmedCheckbox).toBeVisible();
+        await expect(apiKeysPage.copyConfirmedCheckbox).not.toBeChecked();
+      });
+
+      await test.step('Check confirmation and close', async () => {
+        await apiKeysPage.copyConfirmedCheckbox.check();
+        await expect(apiKeysPage.copyConfirmedCheckbox).toBeChecked();
+        await apiKeysPage.closeNewKeyModalButton.click();
+        await expect(apiKeysPage.newKeyModal).not.toBeVisible();
+      });
+
+      // Clean up
+      await apiKeysPage.deleteKey(keyName);
+    });
+
+    test('should add new key to the list after creation', async ({ page }) => {
+      const keyName = `List Test ${Date.now()}`;
+
+      const initialCount = await apiKeysPage.getKeyCount();
+
+      await apiKeysPage.createKey(keyName);
+      await apiKeysPage.closeNewKeyModal();
+
+      await test.step('Verify key count increased', async () => {
+        const newCount = await apiKeysPage.getKeyCount();
+        expect(newCount).toBe(initialCount + 1);
+      });
+
+      await test.step('Verify key name in list', async () => {
+        const names = await apiKeysPage.getKeyNames();
+        expect(names).toContain(keyName);
+      });
+
+      // Clean up
+      await apiKeysPage.deleteKey(keyName);
+    });
+
+    test('should create key with different permissions', async ({ page }) => {
+      const readOnlyKeyName = `Read Only ${Date.now()}`;
+      const readWriteKeyName = `Read Write ${Date.now()}`;
+
+      await test.step('Create read-only key', async () => {
+        await apiKeysPage.createKey(readOnlyKeyName, 'READ_ONLY');
+        await apiKeysPage.closeNewKeyModal();
+        await apiKeysPage.assertKeyExists(readOnlyKeyName);
+      });
+
+      await test.step('Create read-write key', async () => {
+        await apiKeysPage.createKey(readWriteKeyName, 'READ_WRITE');
+        await apiKeysPage.closeNewKeyModal();
+        await apiKeysPage.assertKeyExists(readWriteKeyName);
+      });
+
+      // Clean up
+      await apiKeysPage.deleteKey(readOnlyKeyName);
+      await apiKeysPage.deleteKey(readWriteKeyName);
+    });
+  });
+
+  test.describe('List API Keys', () => {
+    test('should show empty state when no keys exist', async ({ page }) => {
+      // This test assumes no keys exist initially
+      // Skip if keys already exist
+      const keyCount = await apiKeysPage.getKeyCount();
+      if (keyCount > 0) {
+        test.skip();
+        return;
+      }
+
+      await apiKeysPage.assertNoKeys();
+    });
+
+    test('should display key metadata (name, prefix, last used)', async ({ page }) => {
+      const keyName = `Metadata Test ${Date.now()}`;
+
+      await apiKeysPage.createKey(keyName);
+      await apiKeysPage.closeNewKeyModal();
+
+      const keyItem = apiKeysPage.getKeyByName(keyName);
+
+      await test.step('Verify key name is displayed', async () => {
+        await expect(keyItem.locator('[data-testid="api-key-name"]')).toContainText(keyName);
+      });
+
+      await test.step('Verify key prefix is displayed (masked)', async () => {
+        // Key prefix is shown like "sk_xxx..."
+        await expect(keyItem).toContainText('...');
+      });
+
+      // Clean up
+      await apiKeysPage.deleteKey(keyName);
+    });
+  });
+
+  test.describe('Revoke API Key', () => {
+    test('should revoke key with confirmation dialog', async ({ page }) => {
+      const keyName = `Revoke Test ${Date.now()}`;
+
+      // Create a key first
+      await apiKeysPage.createKey(keyName);
+      await apiKeysPage.closeNewKeyModal();
+      await apiKeysPage.assertKeyExists(keyName);
+
+      await test.step('Revoke the key', async () => {
+        await apiKeysPage.deleteKey(keyName);
+      });
+
+      await test.step('Verify key is removed from list', async () => {
+        await apiKeysPage.assertKeyNotExists(keyName);
+      });
+    });
+
+    test('should update key count after revocation', async ({ page }) => {
+      const keyName = `Count Test ${Date.now()}`;
+
+      await apiKeysPage.createKey(keyName);
+      await apiKeysPage.closeNewKeyModal();
+
+      const countBefore = await apiKeysPage.getKeyCount();
+
+      await apiKeysPage.deleteKey(keyName);
+
+      const countAfter = await apiKeysPage.getKeyCount();
+      expect(countAfter).toBe(countBefore - 1);
+    });
+  });
+
+  test.describe('API Key Usage', () => {
+    test('should allow API request with valid key', async ({ page, request }) => {
+      const keyName = `Usage Test ${Date.now()}`;
+
+      // Create a key
+      const apiKey = await apiKeysPage.createKey(keyName, 'READ_ONLY');
+      await apiKeysPage.closeNewKeyModal();
+
+      await test.step('Make API request with the key', async () => {
+        const response = await request.get('/api/keys', {
+          headers: {
+            Authorization: `Bearer ${apiKey}`,
+          },
+        });
+
+        expect(response.ok()).toBe(true);
+        const data = await response.json();
+        expect(data.keys).toBeDefined();
+      });
+
+      // Clean up
+      await apiKeysPage.deleteKey(keyName);
+    });
+
+    test('should reject API request with invalid key', async ({ request }) => {
+      await test.step('Make API request with invalid key', async () => {
+        const response = await request.get('/api/keys', {
+          headers: {
+            Authorization: 'Bearer invalid_key_12345',
+          },
+        });
+
+        expect(response.status()).toBe(401);
+      });
+    });
+
+    test('should reject API request with revoked key', async ({ page, request }) => {
+      const keyName = `Revoked Key Test ${Date.now()}`;
+
+      // Create and capture the key
+      const apiKey = await apiKeysPage.createKey(keyName);
+      await apiKeysPage.closeNewKeyModal();
+
+      // Verify it works initially
+      await test.step('Verify key works before revocation', async () => {
+        const response = await request.get('/api/keys', {
+          headers: {
+            Authorization: `Bearer ${apiKey}`,
+          },
+        });
+        expect(response.ok()).toBe(true);
+      });
+
+      // Revoke the key
+      await apiKeysPage.deleteKey(keyName);
+
+      // Verify it no longer works
+      await test.step('Verify key fails after revocation', async () => {
+        const response = await request.get('/api/keys', {
+          headers: {
+            Authorization: `Bearer ${apiKey}`,
+          },
+        });
+        expect(response.status()).toBe(401);
+      });
+    });
+  });
+});

--- a/tests/pages/ApiKeysPage.ts
+++ b/tests/pages/ApiKeysPage.ts
@@ -1,0 +1,184 @@
+import { Page, Locator, expect } from '@playwright/test';
+import { BasePage } from './BasePage';
+
+/**
+ * Page object for API Keys management (/profile/security)
+ */
+export class ApiKeysPage extends BasePage {
+  // Main elements
+  readonly createKeyButton: Locator;
+  readonly keysList: Locator;
+  readonly emptyMessage: Locator;
+
+  // Create modal elements
+  readonly createModal: Locator;
+  readonly nameInput: Locator;
+  readonly permissionSelect: Locator;
+  readonly cancelCreateButton: Locator;
+  readonly confirmCreateButton: Locator;
+
+  // New key modal elements
+  readonly newKeyModal: Locator;
+  readonly newKeyValue: Locator;
+  readonly copyKeyButton: Locator;
+  readonly copyConfirmedCheckbox: Locator;
+  readonly closeNewKeyModalButton: Locator;
+
+  constructor(page: Page) {
+    super(page);
+
+    // Main elements
+    this.createKeyButton = this.page.locator('[data-testid="create-api-key-button"]');
+    this.keysList = this.page.locator('[data-testid="api-keys-list"]');
+    this.emptyMessage = this.page.locator('[data-testid="empty-keys-message"]');
+
+    // Create modal elements
+    this.createModal = this.page.locator('[data-testid="create-key-modal"]');
+    this.nameInput = this.page.locator('[data-testid="api-key-name-input"]');
+    this.permissionSelect = this.page.locator('[data-testid="api-key-permission-select"]');
+    this.cancelCreateButton = this.page.locator('[data-testid="cancel-create-key-button"]');
+    this.confirmCreateButton = this.page.locator('[data-testid="confirm-create-key-button"]');
+
+    // New key modal elements
+    this.newKeyModal = this.page.locator('[data-testid="new-key-modal"]');
+    this.newKeyValue = this.page.locator('[data-testid="new-api-key-value"]');
+    this.copyKeyButton = this.page.locator('[data-testid="copy-api-key-button"]');
+    this.copyConfirmedCheckbox = this.page.locator('[data-testid="copy-confirmed-checkbox"]');
+    this.closeNewKeyModalButton = this.page.locator('[data-testid="close-new-key-modal-button"]');
+  }
+
+  /**
+   * Navigate to the security settings page where API keys are managed
+   */
+  async goto(): Promise<void> {
+    await this.navigateTo('/profile/security');
+    // Wait for API keys section to load
+    await this.page.waitForSelector('[data-testid="create-api-key-button"], [data-testid="empty-keys-message"]', {
+      timeout: 10000,
+    });
+  }
+
+  /**
+   * Open the create key modal
+   */
+  async openCreateModal(): Promise<void> {
+    await this.createKeyButton.click();
+    await expect(this.createModal).toBeVisible();
+  }
+
+  /**
+   * Create a new API key with the given name and permission
+   */
+  async createKey(name: string, permission: 'READ_ONLY' | 'READ_WRITE' = 'READ_ONLY'): Promise<string> {
+    await this.openCreateModal();
+
+    // Fill in the form
+    await this.nameInput.fill(name);
+    await this.permissionSelect.selectOption(permission);
+
+    // Submit
+    await this.confirmCreateButton.click();
+
+    // Wait for new key modal to appear
+    await expect(this.newKeyModal).toBeVisible({ timeout: 10000 });
+
+    // Get the key value
+    const keyValue = await this.newKeyValue.textContent();
+    if (!keyValue) {
+      throw new Error('Failed to get new API key value');
+    }
+
+    return keyValue.trim();
+  }
+
+  /**
+   * Close the new key modal after copying
+   */
+  async closeNewKeyModal(confirmCopy = true): Promise<void> {
+    if (confirmCopy) {
+      await this.copyConfirmedCheckbox.check();
+    }
+    await this.closeNewKeyModalButton.click();
+    await expect(this.newKeyModal).not.toBeVisible();
+  }
+
+  /**
+   * Get a key item by name
+   */
+  getKeyByName(name: string): Locator {
+    return this.page.locator(`[data-key-name="${name}"]`);
+  }
+
+  /**
+   * Delete a key by name
+   */
+  async deleteKey(name: string): Promise<void> {
+    const keyItem = this.getKeyByName(name);
+    await expect(keyItem).toBeVisible();
+
+    // Set up dialog handler for confirmation
+    this.page.once('dialog', (dialog) => dialog.accept());
+
+    // Click delete button within this key item
+    await keyItem.locator('[data-testid="delete-api-key-button"]').click();
+
+    // Wait for key to be removed
+    await expect(keyItem).not.toBeVisible({ timeout: 5000 });
+  }
+
+  /**
+   * Get all key names currently displayed
+   */
+  async getKeyNames(): Promise<string[]> {
+    const nameElements = this.page.locator('[data-testid="api-key-name"]');
+    const count = await nameElements.count();
+    const names: string[] = [];
+
+    for (let i = 0; i < count; i++) {
+      const name = await nameElements.nth(i).textContent();
+      if (name) {
+        names.push(name.trim());
+      }
+    }
+
+    return names;
+  }
+
+  /**
+   * Get count of API keys displayed
+   */
+  async getKeyCount(): Promise<number> {
+    const keys = this.page.locator('[data-testid^="api-key-item-"]');
+    return keys.count();
+  }
+
+  /**
+   * Assert that no keys are displayed
+   */
+  async assertNoKeys(): Promise<void> {
+    await expect(this.emptyMessage).toBeVisible();
+  }
+
+  /**
+   * Assert that keys list is visible with at least one key
+   */
+  async assertHasKeys(): Promise<void> {
+    await expect(this.keysList).toBeVisible();
+  }
+
+  /**
+   * Assert a key with given name exists
+   */
+  async assertKeyExists(name: string): Promise<void> {
+    const keyItem = this.getKeyByName(name);
+    await expect(keyItem).toBeVisible();
+  }
+
+  /**
+   * Assert a key with given name does not exist
+   */
+  async assertKeyNotExists(name: string): Promise<void> {
+    const keyItem = this.getKeyByName(name);
+    await expect(keyItem).not.toBeVisible();
+  }
+}


### PR DESCRIPTION
## Summary
- Add data-testid attributes to API keys component for E2E test targeting
- Create ApiKeysPage page object for API keys management flows
- Add comprehensive E2E tests covering CRUD operations and API authentication

Closes #311

## Test plan
- [x] Tests cover creating API keys with name and permissions
- [x] Tests cover listing and verifying key metadata
- [x] Tests cover revoking keys with confirmation
- [x] Tests cover API authentication with valid/invalid/revoked keys

🤖 Generated with [Claude Code](https://claude.com/claude-code)