### PR TITLE
test(e2e): add account unlock flow E2E tests

### DIFF
--- a/src/app/request-unlock/page.tsx
+++ b/src/app/request-unlock/page.tsx
@@ -58,14 +58,14 @@ function RequestUnlockForm() {
 
   if (success) {
     return (
-      <div className="flex min-h-screen items-center justify-center bg-gray-50 px-4 py-12 sm:px-6 lg:px-8">
+      <div className="flex min-h-screen items-center justify-center bg-gray-50 px-4 py-12 sm:px-6 lg:px-8" data-testid="request-unlock-success">
         <Card className="w-full max-w-md">
           <CardHeader>
             <div className="mx-auto flex h-12 w-12 items-center justify-center rounded-full bg-green-100">
               <Unlock className="h-6 w-6 text-green-600" />
             </div>
-            <CardTitle className="mt-4 text-center">Check Your Email</CardTitle>
-            <CardDescription className="text-center">
+            <CardTitle className="mt-4 text-center" data-testid="success-title">Check Your Email</CardTitle>
+            <CardDescription className="text-center" data-testid="success-description">
               If your account is locked, we&apos;ve sent you an email with
               instructions to unlock it.
             </CardDescription>
@@ -76,7 +76,7 @@ function RequestUnlockForm() {
               email, check your spam folder.
             </p>
             <Link href="/login">
-              <Button variant="outline" className="w-full">
+              <Button variant="outline" className="w-full" data-testid="back-to-login-button">
                 <ArrowLeft className="mr-2 h-4 w-4" />
                 Back to Login
               </Button>
@@ -88,7 +88,7 @@ function RequestUnlockForm() {
   }
 
   return (
-    <div className="flex min-h-screen items-center justify-center bg-gray-50 px-4 py-12 sm:px-6 lg:px-8">
+    <div className="flex min-h-screen items-center justify-center bg-gray-50 px-4 py-12 sm:px-6 lg:px-8" data-testid="request-unlock-page">
       <Card className="w-full max-w-md">
         <CardHeader>
           <CardTitle>Unlock Your Account</CardTitle>
@@ -99,12 +99,12 @@ function RequestUnlockForm() {
         </CardHeader>
         <CardContent>
           {error && (
-            <Alert variant="error" className="mb-4">
+            <Alert variant="error" className="mb-4" data-testid="error-message">
               {error}
             </Alert>
           )}
 
-          <form onSubmit={handleSubmit} className="space-y-4">
+          <form onSubmit={handleSubmit} className="space-y-4" data-testid="request-unlock-form">
             <div className="space-y-2">
               <label htmlFor="email" className="text-sm font-medium">
                 Email Address
@@ -119,10 +119,11 @@ function RequestUnlockForm() {
                 onChange={(e) => setEmail(e.target.value)}
                 disabled={isLoading}
                 placeholder="you@example.com"
+                data-testid="email-input"
               />
             </div>
 
-            <Button type="submit" className="w-full" disabled={isLoading}>
+            <Button type="submit" className="w-full" disabled={isLoading} data-testid="submit-button">
               <Unlock className="mr-2 h-4 w-4" />
               {isLoading ? 'Sending...' : 'Send Unlock Link'}
             </Button>
@@ -131,6 +132,7 @@ function RequestUnlockForm() {
               <Link
                 href="/login"
                 className="text-sm text-gray-600 hover:text-gray-900"
+                data-testid="back-to-login-link"
               >
                 <ArrowLeft className="mr-1 inline h-3 w-3" />
                 Back to Login

--- a/src/app/unlock-account/page.tsx
+++ b/src/app/unlock-account/page.tsx
@@ -58,7 +58,7 @@ function UnlockAccountContent() {
 
   if (status === 'loading') {
     return (
-      <div className="flex min-h-screen items-center justify-center bg-gray-50 px-4 py-12 sm:px-6 lg:px-8">
+      <div className="flex min-h-screen items-center justify-center bg-gray-50 px-4 py-12 sm:px-6 lg:px-8" data-testid="unlock-loading">
         <Card className="w-full max-w-md">
           <CardContent className="pt-6">
             <div className="flex flex-col items-center justify-center py-8">
@@ -73,20 +73,20 @@ function UnlockAccountContent() {
 
   if (status === 'no-token') {
     return (
-      <div className="flex min-h-screen items-center justify-center bg-gray-50 px-4 py-12 sm:px-6 lg:px-8">
+      <div className="flex min-h-screen items-center justify-center bg-gray-50 px-4 py-12 sm:px-6 lg:px-8" data-testid="unlock-no-token">
         <Card className="w-full max-w-md">
           <CardHeader>
             <div className="mx-auto flex h-12 w-12 items-center justify-center rounded-full bg-yellow-100">
               <Unlock className="h-6 w-6 text-yellow-600" />
             </div>
-            <CardTitle className="mt-4 text-center">Invalid Link</CardTitle>
+            <CardTitle className="mt-4 text-center" data-testid="no-token-title">Invalid Link</CardTitle>
             <CardDescription className="text-center">
               This unlock link appears to be invalid or incomplete.
             </CardDescription>
           </CardHeader>
           <CardContent>
             <Link href="/request-unlock">
-              <Button className="w-full">Request New Unlock Link</Button>
+              <Button className="w-full" data-testid="request-new-link-button">Request New Unlock Link</Button>
             </Link>
           </CardContent>
         </Card>
@@ -96,24 +96,24 @@ function UnlockAccountContent() {
 
   if (status === 'error') {
     return (
-      <div className="flex min-h-screen items-center justify-center bg-gray-50 px-4 py-12 sm:px-6 lg:px-8">
+      <div className="flex min-h-screen items-center justify-center bg-gray-50 px-4 py-12 sm:px-6 lg:px-8" data-testid="unlock-error">
         <Card className="w-full max-w-md">
           <CardHeader>
             <div className="mx-auto flex h-12 w-12 items-center justify-center rounded-full bg-red-100">
               <XCircle className="h-6 w-6 text-red-600" />
             </div>
-            <CardTitle className="mt-4 text-center">Unlock Failed</CardTitle>
+            <CardTitle className="mt-4 text-center" data-testid="error-title">Unlock Failed</CardTitle>
           </CardHeader>
           <CardContent>
-            <Alert variant="error" className="mb-4">
+            <Alert variant="error" className="mb-4" data-testid="error-message">
               {message}
             </Alert>
             <div className="space-y-3">
               <Link href="/request-unlock">
-                <Button className="w-full">Request New Unlock Link</Button>
+                <Button className="w-full" data-testid="request-new-link-button">Request New Unlock Link</Button>
               </Link>
               <Link href="/login">
-                <Button variant="outline" className="w-full">
+                <Button variant="outline" className="w-full" data-testid="back-to-login-button">
                   Back to Login
                 </Button>
               </Link>
@@ -125,18 +125,18 @@ function UnlockAccountContent() {
   }
 
   return (
-    <div className="flex min-h-screen items-center justify-center bg-gray-50 px-4 py-12 sm:px-6 lg:px-8">
+    <div className="flex min-h-screen items-center justify-center bg-gray-50 px-4 py-12 sm:px-6 lg:px-8" data-testid="unlock-success">
       <Card className="w-full max-w-md">
         <CardHeader>
           <div className="mx-auto flex h-12 w-12 items-center justify-center rounded-full bg-green-100">
             <CheckCircle className="h-6 w-6 text-green-600" />
           </div>
-          <CardTitle className="mt-4 text-center">Account Unlocked!</CardTitle>
-          <CardDescription className="text-center">{message}</CardDescription>
+          <CardTitle className="mt-4 text-center" data-testid="success-title">Account Unlocked!</CardTitle>
+          <CardDescription className="text-center" data-testid="success-message">{message}</CardDescription>
         </CardHeader>
         <CardContent>
           <Link href="/login">
-            <Button className="w-full">Sign In Now</Button>
+            <Button className="w-full" data-testid="sign-in-button">Sign In Now</Button>
           </Link>
         </CardContent>
       </Card>

--- a/tests/e2e/auth/account-unlock.spec.ts
+++ b/tests/e2e/auth/account-unlock.spec.ts
@@ -1,0 +1,195 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Account Unlock Flow', () => {
+  test.describe('Request Unlock Page', () => {
+    test.beforeEach(async ({ page }) => {
+      await page.goto('/request-unlock');
+    });
+
+    test('should display request unlock form', async ({ page }) => {
+      await expect(page.locator('[data-testid="request-unlock-page"]')).toBeVisible();
+      await expect(page.locator('[data-testid="request-unlock-form"]')).toBeVisible();
+      await expect(page.locator('[data-testid="email-input"]')).toBeVisible();
+      await expect(page.locator('[data-testid="submit-button"]')).toBeVisible();
+    });
+
+    test('should have back to login link', async ({ page }) => {
+      const backLink = page.locator('[data-testid="back-to-login-link"]');
+      await expect(backLink).toBeVisible();
+      await expect(backLink).toContainText('Back to Login');
+    });
+
+    test('should require email field', async ({ page }) => {
+      await page.locator('[data-testid="submit-button"]').click();
+      // HTML5 validation should prevent submission
+      const emailInput = page.locator('[data-testid="email-input"]');
+      await expect(emailInput).toHaveAttribute('required', '');
+    });
+
+    test('should submit unlock request with email', async ({ page }) => {
+      const testEmail = 'test@example.com';
+
+      await page.locator('[data-testid="email-input"]').fill(testEmail);
+      await page.locator('[data-testid="submit-button"]').click();
+
+      // Wait for either success or error state
+      // Success shows the success page, error shows error message
+      await expect(
+        page.locator('[data-testid="request-unlock-success"], [data-testid="error-message"]')
+      ).toBeVisible({ timeout: 10000 });
+    });
+
+    test('should show success message after submission', async ({ page }) => {
+      // Use a generic email - the system shows success regardless of whether account exists
+      // to prevent email enumeration
+      await page.locator('[data-testid="email-input"]').fill('test@example.com');
+      await page.locator('[data-testid="submit-button"]').click();
+
+      // Should show success page (system doesn't reveal if email exists)
+      await expect(page.locator('[data-testid="request-unlock-success"]')).toBeVisible({
+        timeout: 10000,
+      });
+      await expect(page.locator('[data-testid="success-title"]')).toContainText('Check Your Email');
+    });
+
+    test('should have back to login button on success page', async ({ page }) => {
+      await page.locator('[data-testid="email-input"]').fill('test@example.com');
+      await page.locator('[data-testid="submit-button"]').click();
+
+      await expect(page.locator('[data-testid="request-unlock-success"]')).toBeVisible({
+        timeout: 10000,
+      });
+
+      const backButton = page.locator('[data-testid="back-to-login-button"]');
+      await expect(backButton).toBeVisible();
+    });
+
+    test('should pre-fill email from query parameter', async ({ page }) => {
+      const testEmail = 'prefilled@example.com';
+      await page.goto(`/request-unlock?email=${encodeURIComponent(testEmail)}`);
+
+      const emailInput = page.locator('[data-testid="email-input"]');
+      await expect(emailInput).toHaveValue(testEmail);
+    });
+  });
+
+  test.describe('Unlock Account Page', () => {
+    test('should show invalid link message without token', async ({ page }) => {
+      await page.goto('/unlock-account');
+
+      await expect(page.locator('[data-testid="unlock-no-token"]')).toBeVisible();
+      await expect(page.locator('[data-testid="no-token-title"]')).toContainText('Invalid Link');
+    });
+
+    test('should have request new link button when no token', async ({ page }) => {
+      await page.goto('/unlock-account');
+
+      const requestButton = page.locator('[data-testid="request-new-link-button"]');
+      await expect(requestButton).toBeVisible();
+      await expect(requestButton).toContainText('Request New Unlock Link');
+    });
+
+    test('should show error for invalid token', async ({ page }) => {
+      await page.goto('/unlock-account?token=invalid_token_12345');
+
+      // Should show error state
+      await expect(page.locator('[data-testid="unlock-error"]')).toBeVisible({ timeout: 10000 });
+      await expect(page.locator('[data-testid="error-title"]')).toContainText('Unlock Failed');
+    });
+
+    test('should have request new link and back to login buttons on error', async ({ page }) => {
+      await page.goto('/unlock-account?token=invalid_token_12345');
+
+      await expect(page.locator('[data-testid="unlock-error"]')).toBeVisible({ timeout: 10000 });
+
+      await expect(page.locator('[data-testid="request-new-link-button"]')).toBeVisible();
+      await expect(page.locator('[data-testid="back-to-login-button"]')).toBeVisible();
+    });
+
+    test('should display error message for expired token', async ({ page }) => {
+      // Using a token that would be expired
+      await page.goto('/unlock-account?token=expired_token_12345');
+
+      await expect(page.locator('[data-testid="unlock-error"]')).toBeVisible({ timeout: 10000 });
+      await expect(page.locator('[data-testid="error-message"]')).toBeVisible();
+    });
+  });
+
+  test.describe('Navigation Flow', () => {
+    test('should navigate to login from request unlock page', async ({ page }) => {
+      await page.goto('/request-unlock');
+
+      await page.locator('[data-testid="back-to-login-link"]').click();
+      await expect(page).toHaveURL(/.*\/login/);
+    });
+
+    test('should navigate to request unlock from unlock error page', async ({ page }) => {
+      await page.goto('/unlock-account?token=invalid_token');
+
+      await expect(page.locator('[data-testid="unlock-error"]')).toBeVisible({ timeout: 10000 });
+
+      await page.locator('[data-testid="request-new-link-button"]').click();
+      await expect(page).toHaveURL(/.*\/request-unlock/);
+    });
+
+    test('should navigate to login from unlock error page', async ({ page }) => {
+      await page.goto('/unlock-account?token=invalid_token');
+
+      await expect(page.locator('[data-testid="unlock-error"]')).toBeVisible({ timeout: 10000 });
+
+      await page.locator('[data-testid="back-to-login-button"]').click();
+      await expect(page).toHaveURL(/.*\/login/);
+    });
+
+    test('should navigate to request unlock from no token page', async ({ page }) => {
+      await page.goto('/unlock-account');
+
+      await expect(page.locator('[data-testid="unlock-no-token"]')).toBeVisible();
+
+      await page.locator('[data-testid="request-new-link-button"]').click();
+      await expect(page).toHaveURL(/.*\/request-unlock/);
+    });
+  });
+
+  test.describe('Form Validation', () => {
+    test('should validate email format', async ({ page }) => {
+      await page.goto('/request-unlock');
+
+      const emailInput = page.locator('[data-testid="email-input"]');
+      await emailInput.fill('invalid-email');
+
+      await page.locator('[data-testid="submit-button"]').click();
+
+      // HTML5 email validation should prevent submission
+      // Check that we're still on the request unlock page
+      await expect(page.locator('[data-testid="request-unlock-page"]')).toBeVisible();
+    });
+
+    test('should accept valid email format', async ({ page }) => {
+      await page.goto('/request-unlock');
+
+      await page.locator('[data-testid="email-input"]').fill('valid@example.com');
+      await page.locator('[data-testid="submit-button"]').click();
+
+      // Should proceed to success state
+      await expect(
+        page.locator('[data-testid="request-unlock-success"], [data-testid="error-message"]')
+      ).toBeVisible({ timeout: 10000 });
+    });
+  });
+
+  test.describe('Security', () => {
+    test('should not reveal if email exists in system', async ({ page }) => {
+      await page.goto('/request-unlock');
+
+      // Submit with non-existent email
+      await page.locator('[data-testid="email-input"]').fill('nonexistent@example.com');
+      await page.locator('[data-testid="submit-button"]').click();
+
+      // Should still show success message (no email enumeration)
+      await expect(page.locator('[data-testid="request-unlock-success"]')).toBeVisible({
+        timeout: 10000,
+      });
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Added data-testid attributes to request-unlock and unlock-account pages
- Created comprehensive E2E tests for account unlock flow including form validation, navigation, and security tests

## Test plan
- [x] Request unlock page displays form correctly
- [x] Unlock account page handles missing/invalid tokens
- [x] Navigation between unlock pages and login works
- [x] Email format validation works
- [x] No email enumeration (security test)

Closes #312

🤖 Generated with [Claude Code](https://claude.com/claude-code)